### PR TITLE
Fix version extraction with missing delimiters

### DIFF
--- a/src/main/java/com/rannett/fixplugin/util/FixUtils.java
+++ b/src/main/java/com/rannett/fixplugin/util/FixUtils.java
@@ -1,6 +1,8 @@
 package com.rannett.fixplugin.util;
 
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class FixUtils {
 
@@ -12,12 +14,12 @@ public class FixUtils {
 
         String candidate = text.substring(start + 2);
 
-        java.util.regex.Matcher m = java.util.regex.Pattern
+        Matcher matcher = Pattern
                 .compile("^(FIX(?:T)?\\.[0-9]+(?:\\.[0-9]+)*)(?:[\\u0001|\\s]|$)")
                 .matcher(candidate);
 
-        if (m.find()) {
-            return Optional.of(m.group(1));
+        if (matcher.find()) {
+            return Optional.of(matcher.group(1));
         }
 
         return Optional.empty();

--- a/src/main/java/com/rannett/fixplugin/util/FixUtils.java
+++ b/src/main/java/com/rannett/fixplugin/util/FixUtils.java
@@ -6,6 +6,9 @@ import java.util.regex.Pattern;
 
 public class FixUtils {
 
+    private static final Pattern FIX_VERSION_PATTERN = Pattern.compile(
+            "^(FIX(?:T)?\\.[0-9]+(?:\\.[0-9]+)*)(?:[\\u0001|\\s]|$)");
+
     public static Optional<String> extractFixVersion(String text) {
         int start = text.indexOf("8=FIX");
         if (start == -1) {
@@ -14,9 +17,7 @@ public class FixUtils {
 
         String candidate = text.substring(start + 2);
 
-        Matcher matcher = Pattern
-                .compile("^(FIX(?:T)?\\.[0-9]+(?:\\.[0-9]+)*)(?:[\\u0001|\\s]|$)")
-                .matcher(candidate);
+        Matcher matcher = FIX_VERSION_PATTERN.matcher(candidate);
 
         if (matcher.find()) {
             return Optional.of(matcher.group(1));

--- a/src/main/java/com/rannett/fixplugin/util/FixUtils.java
+++ b/src/main/java/com/rannett/fixplugin/util/FixUtils.java
@@ -10,21 +10,16 @@ public class FixUtils {
             return Optional.empty();
         }
 
-        int endPipe = text.indexOf('|', start);
-        int endSoh = text.indexOf('\u0001', start);
-        int end;
+        String candidate = text.substring(start + 2);
 
-        if (endPipe == -1 && endSoh == -1) {
-            end = text.length();
-        } else if (endPipe == -1) {
-            end = endSoh;
-        } else if (endSoh == -1) {
-            end = endPipe;
-        } else {
-            end = Math.min(endPipe, endSoh);
+        java.util.regex.Matcher m = java.util.regex.Pattern
+                .compile("^(FIX(?:T)?\\.[0-9]+(?:\\.[0-9]+)*)(?:[\\u0001|\\s]|$)")
+                .matcher(candidate);
+
+        if (m.find()) {
+            return Optional.of(m.group(1));
         }
 
-        String versionField = text.substring(start + 2, end);
-        return Optional.of(versionField);
+        return Optional.empty();
     }
 }

--- a/src/test/java/com/rannett/fixplugin/util/FixUtilsTest.java
+++ b/src/test/java/com/rannett/fixplugin/util/FixUtilsTest.java
@@ -56,4 +56,12 @@ public class FixUtilsTest {
         assertTrue(version.isPresent());
         assertEquals("FIXT.1.1", version.get());
     }
+
+    @Test
+    public void testExtractFixVersion_noDelimitersAtAll() {
+        String text = "8=FIX.4.2 9=5 35=A";
+        Optional<String> version = FixUtils.extractFixVersion(text);
+        assertTrue(version.isPresent());
+        assertEquals("FIX.4.2", version.get());
+    }
 }

--- a/src/test/java/com/rannett/fixplugin/util/FixUtilsTest.java
+++ b/src/test/java/com/rannett/fixplugin/util/FixUtilsTest.java
@@ -48,4 +48,12 @@ public class FixUtilsTest {
         assertTrue(version.isPresent());
         assertEquals("FIX.4.2", version.get());
     }
+
+    @Test
+    public void testExtractFixVersion_missingDelimiter() {
+        String text = "8=FIXT.1.1 9=123|35=A|";
+        Optional<String> version = FixUtils.extractFixVersion(text);
+        assertTrue(version.isPresent());
+        assertEquals("FIXT.1.1", version.get());
+    }
 }


### PR DESCRIPTION
## Summary
- handle missing delimiter characters when parsing FIX version
- cover the corner case with a unit test

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684004d741e8832cafc0ce76d4427499