### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This plugin provides rich syntax highlighting for FIX messages (`.fix` files), m
 read and debug. Each field and value is colour-coded for clarity, with support for message types, tags, values, and
 separators, helping users spot issues quickly. Incorrect checksums are highlighted and can be automatically corrected.
 
-Users can also view these messages in a transposed table view, which is much easier that scrolling horizontally. The
+Users can also view these messages in a transposed table view, which is much easier than scrolling horizontally. The
 same
 fields for different messages will be shown in the same row, making comparison easier.
 


### PR DESCRIPTION
## Summary
- fix 'that' to 'than' in README

## Testing
- `./gradlew test --no-daemon` *(fails: No IntelliJ Platform dependency found)*

------
https://chatgpt.com/codex/tasks/task_e_684073a7f570832cb91d397d5a316f68