### PR TITLE
Add unit test for FixTransposedTableModel

### DIFF
--- a/src/main/java/com/rannett/fixplugin/ui/FixTransposedTableModel.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixTransposedTableModel.java
@@ -130,7 +130,9 @@ public class FixTransposedTableModel extends AbstractTableModel {
     }
 
     public String getMessageIdForColumn(int columnIndex) {
-        return columnIndex >= 2 ? columnHeaders.get(columnIndex - 2) : null;
+        if (columnIndex < 2) return null;
+        int modelIndex = columnIndex - 2;
+        return modelIndex >= 0 && modelIndex < columnHeaders.size() ? columnHeaders.get(modelIndex) : null;
     }
 
     public String getFixVersion() {

--- a/src/test/java/com/rannett/fixplugin/ui/FixTransposedTableModelTest.java
+++ b/src/test/java/com/rannett/fixplugin/ui/FixTransposedTableModelTest.java
@@ -1,0 +1,19 @@
+package com.rannett.fixplugin.ui;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class FixTransposedTableModelTest {
+    @Test
+    public void testGetMessageIdForColumn_bounds() {
+        List<String> messages = List.of("8=FIX.4.4|35=A|10=000|");
+        FixTransposedTableModel model = new FixTransposedTableModel(messages, (id, tag, value) -> {}, null);
+
+        assertEquals("Message 1", model.getMessageIdForColumn(2));
+        assertNull(model.getMessageIdForColumn(1));
+        assertNull(model.getMessageIdForColumn(3));
+    }
+}


### PR DESCRIPTION
## Summary
- guard `FixTransposedTableModel#getMessageIdForColumn` from invalid indexes
- add regression test verifying out-of-bounds access

## Testing
- `./gradlew test --no-daemon` *(fails: Could not resolve all dependencies for configuration :testRuntimeClasspath)*

------
https://chatgpt.com/codex/tasks/task_e_6842a522bcd0832cb28238f802127f19