### PR TITLE
Improve dictionary load handling

### DIFF
--- a/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryCache.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryCache.java
@@ -28,11 +28,7 @@ public final class FixDictionaryCache {
 
         String customPath = settings.getCustomDictionaryPath(fixVersion);
         if (customPath != null && !customPath.isEmpty()) {
-            try {
-                return FixTagDictionary.fromFile(new java.io.File(customPath));
-            } catch (Exception e) {
-                //System.err.println("Failed to load custom dictionary for version " + fixVersion + ": " + e.getMessage());
-            }
+            return FixTagDictionary.fromFile(new java.io.File(customPath));
         }
 
         return FixTagDictionary.fromBuiltInVersion(fixVersion);

--- a/src/main/java/com/rannett/fixplugin/dictionary/FixTagDictionary.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/FixTagDictionary.java
@@ -1,5 +1,6 @@
 package com.rannett.fixplugin.dictionary;
 
+import com.intellij.openapi.diagnostic.Logger;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.BufferedReader;
@@ -13,6 +14,8 @@ import java.util.Map;
 
 public class FixTagDictionary {
 
+    private static final Logger LOG = Logger.getInstance(FixTagDictionary.class);
+
     private final Map<String, String> tagNameMap = new HashMap<>();
     private final Map<String, Map<String, String>> tagValueMap = new HashMap<>();
     private final Map<String, String> fieldTypeMap = new HashMap<>(); // New map for field types
@@ -20,7 +23,7 @@ public class FixTagDictionary {
     FixTagDictionary() {
     }
 
-    public static FixTagDictionary fromFile(@NotNull File file) throws Exception {
+    public static FixTagDictionary fromFile(@NotNull File file) {
         FixTagDictionary dictionary = new FixTagDictionary();
         String fileName = file.getName().toLowerCase();
 
@@ -30,8 +33,10 @@ public class FixTagDictionary {
             } else if (fileName.endsWith(".xml")) {
                 parseXml(reader, dictionary);
             } else {
-                throw new IllegalArgumentException("Unsupported file format: " + fileName);
+                LOG.warn("Unsupported file format: " + fileName);
             }
+        } catch (Exception e) {
+            LOG.warn("Failed to load dictionary file: " + fileName, e);
         }
 
         return dictionary;
@@ -43,15 +48,16 @@ public class FixTagDictionary {
         String resourcePath = "/dictionaries/" + version + ".xml";
         try (InputStream inputStream = FixTagDictionary.class.getResourceAsStream(resourcePath)) {
             if (inputStream == null) {
-                throw new IllegalArgumentException("Built-in dictionary not found: " + version);
+                LOG.warn("Built-in dictionary not found: " + version);
+                return dictionary;
             }
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
                 parseXml(reader, dictionary);
             } catch (Exception e) {
-                throw new RuntimeException("Failed to load built-in dictionary: " + version, e);
+                LOG.warn("Failed to load built-in dictionary: " + version, e);
             }
         } catch (Exception e) {
-            throw new RuntimeException("Failed to load built-in dictionary: " + version, e);
+            LOG.warn("Failed to load built-in dictionary: " + version, e);
         }
 
         return dictionary;

--- a/src/test/java/com/rannett/fixplugin/dictionary/FixTagDictionaryTest.java
+++ b/src/test/java/com/rannett/fixplugin/dictionary/FixTagDictionaryTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertTrue;
 public class FixTagDictionaryTest {
 
     @Test
-    public void testGetTagNameAndValueName_JSON() {
+    public void testGetTagNameAndValueName_JSON() throws Exception {
         String jsonContent = """
                     {
                       "35": {
@@ -47,7 +47,7 @@ public class FixTagDictionaryTest {
     }
 
     @Test
-    public void testGetTagNameAndValueName_XML() {
+    public void testGetTagNameAndValueName_XML() throws Exception {
         String xmlContent = """
                     <dictionary>
                         <field number="35" name="MsgType" type="CHAR">
@@ -78,7 +78,7 @@ public class FixTagDictionaryTest {
     }
 
     @Test
-    public void testGetTagNameMapAndValueMap() {
+    public void testGetTagNameMapAndValueMap() throws Exception {
         String jsonContent = """
                     {
                       "35": {

--- a/src/test/java/com/rannett/fixplugin/dictionary/FixTagDictionaryTest.java
+++ b/src/test/java/com/rannett/fixplugin/dictionary/FixTagDictionaryTest.java
@@ -9,14 +9,13 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 
 public class FixTagDictionaryTest {
 
     @Test
-    public void testGetTagNameAndValueName_JSON() throws Exception {
+    public void testGetTagNameAndValueName_JSON() {
         String jsonContent = """
                     {
                       "35": {
@@ -48,7 +47,7 @@ public class FixTagDictionaryTest {
     }
 
     @Test
-    public void testGetTagNameAndValueName_XML() throws Exception {
+    public void testGetTagNameAndValueName_XML() {
         String xmlContent = """
                     <dictionary>
                         <field number="35" name="MsgType" type="CHAR">
@@ -79,7 +78,7 @@ public class FixTagDictionaryTest {
     }
 
     @Test
-    public void testGetTagNameMapAndValueMap() throws Exception {
+    public void testGetTagNameMapAndValueMap() {
         String jsonContent = """
                     {
                       "35": {
@@ -104,11 +103,53 @@ public class FixTagDictionaryTest {
     }
 
     @Test
+    public void testFromBuiltInVersion_valid() {
+        FixTagDictionary dictionary = FixTagDictionary.fromBuiltInVersion("FIX.4.2");
+        assertEquals("MsgType", dictionary.getTagName("35"));
+        // verify field type lookup from built-in dictionaries
+        assertEquals("STRING", dictionary.getFieldType("35"));
+    }
+
+    @Test
     public void testFromBuiltInVersion_missingFile() {
-        Exception exception = assertThrows(RuntimeException.class, () -> {
-            FixTagDictionary.fromBuiltInVersion("nonexistent-version");
-        });
-        String message = exception.getMessage();
-        assertTrue(message.contains("Failed to load built-in dictionary"));
+        FixTagDictionary dictionary = FixTagDictionary.fromBuiltInVersion("nonexistent-version");
+        assertNull(dictionary.getTagName("35"));
+    }
+
+    @Test
+    public void testFromFile_missingFile() {
+        File missing = new File("does-not-exist.json");
+        FixTagDictionary dictionary = FixTagDictionary.fromFile(missing);
+        assertNull(dictionary.getTagName("35"));
+    }
+
+    @Test
+    public void testFromFile_unsupportedFormat() throws Exception {
+        File tempFile = File.createTempFile("dict", ".txt");
+        try (FileWriter writer = new FileWriter(tempFile)) {
+            writer.write("dummy");
+        }
+        FixTagDictionary dictionary = FixTagDictionary.fromFile(tempFile);
+        assertNull(dictionary.getTagName("35"));
+    }
+
+    @Test
+    public void testFromFile_corruptJson() throws Exception {
+        File tempFile = File.createTempFile("bad", ".json");
+        try (FileWriter writer = new FileWriter(tempFile)) {
+            writer.write("{ bad json");
+        }
+        FixTagDictionary dictionary = FixTagDictionary.fromFile(tempFile);
+        assertNull(dictionary.getTagName("35"));
+    }
+
+    @Test
+    public void testFromFile_corruptXml() throws Exception {
+        File tempFile = File.createTempFile("bad", ".xml");
+        try (FileWriter writer = new FileWriter(tempFile)) {
+            writer.write("<dictionary><field></dictionary>");
+        }
+        FixTagDictionary dictionary = FixTagDictionary.fromFile(tempFile);
+        assertNull(dictionary.getTagName("35"));
     }
 }


### PR DESCRIPTION
## Summary
- log failures when loading FIX dictionaries and return an empty dictionary
- update cache to rely on internal logging
- extend tests for built-in, missing, and corrupt dictionaries
- add tests for field type lookup and unsupported or missing dictionary files

## Testing
- `./gradlew test --stacktrace --no-daemon` *(fails: No IntelliJ Platform dependency found)*

------
https://chatgpt.com/codex/tasks/task_e_684073c01dc4832c8105441526234bc9