### PR TITLE
Gracefully handle FIX messages without delimiters

### DIFF
--- a/src/main/java/com/rannett/fixplugin/ui/FixTransposedTableModel.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixTransposedTableModel.java
@@ -65,7 +65,7 @@ public class FixTransposedTableModel extends AbstractTableModel {
     }
 
     private String detectFixVersion(String message) {
-        return Arrays.stream(message.split("[|\\u0001]")).filter(s -> s.startsWith("8=")).map(s -> s.substring(2)).findFirst().orElse(null);
+        return com.rannett.fixplugin.util.FixUtils.extractFixVersion(message).orElse(null);
     }
 
     private Map<String, String> parseFixMessage(String msg) {


### PR DESCRIPTION
## Summary
- revert accidental support for `!` as a field separator
- delegate version detection to `FixUtils` so malformed messages don't break loading the dictionary

## Testing
- `./gradlew test --no-daemon` *(fails: No IntelliJ Platform dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68407d58026c832cb69e61e9e126d26a