### PR TITLE
Fix transposed view duplicates

### DIFF
--- a/src/main/java/com/rannett/fixplugin/ui/FixDualViewEditor.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixDualViewEditor.java
@@ -50,12 +50,18 @@ public class FixDualViewEditor extends UserDataHolderBase implements FileEditor 
         tabbedPane.addTab("Text View", textEditor.getComponent());
 
         List<String> messages = Arrays.asList(document.getText().split("\\R+"));
-        tablePanel = new FixTransposedTablePanel(messages, (msgId, tag, newValue) -> WriteCommandAction.runWriteCommandAction(project, () -> {
+        tablePanel = new FixTransposedTablePanel(messages, (msgId, tag, occurrence, newValue) -> WriteCommandAction.runWriteCommandAction(project, () -> {
             String[] lines = document.getText().split("\\R+");
             int msgIndex = Integer.parseInt(msgId.replace("Message ", "")) - 1;
             if (msgIndex < 0 || msgIndex >= lines.length) return;
             String message = lines[msgIndex];
-            int tagIndex = message.indexOf(tag + "=");
+            int tagIndex = -1;
+            int fromIndex = 0;
+            for (int occ = 1; occ <= occurrence; occ++) {
+                tagIndex = message.indexOf(tag + "=", fromIndex);
+                if (tagIndex < 0) break;
+                fromIndex = tagIndex + 1;
+            }
             if (tagIndex < 0) return;
             int valueStart = tagIndex + (tag + "=").length();
             int valueEnd = valueStart;

--- a/src/test/java/com/rannett/fixplugin/ui/FixTransposedTableModelTest.java
+++ b/src/test/java/com/rannett/fixplugin/ui/FixTransposedTableModelTest.java
@@ -10,7 +10,7 @@ public class FixTransposedTableModelTest {
     @Test
     public void testGetMessageIdForColumn_bounds() {
         List<String> messages = List.of("8=FIX.4.4|35=A|10=000|");
-        FixTransposedTableModel model = new FixTransposedTableModel(messages, (id, tag, value) -> {}, null);
+        FixTransposedTableModel model = new FixTransposedTableModel(messages, (id, tag, occ, value) -> {}, null);
 
         assertEquals("Message 1", model.getMessageIdForColumn(2));
         assertNull(model.getMessageIdForColumn(1));


### PR DESCRIPTION
## Summary
- handle duplicate tags when building the transposed table
- update editing logic to update the correct tag occurrence

## Testing
- `./gradlew tasks --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684459af03f0832c93694ef1bba95249