### PR TITLE
Fix deprecated API use

### DIFF
--- a/src/main/java/com/rannett/fixplugin/settings/FixViewerSettingsConfigurable.java
+++ b/src/main/java/com/rannett/fixplugin/settings/FixViewerSettingsConfigurable.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import com.intellij.openapi.ui.TextBrowseFolderListener;
 import com.intellij.ui.ToolbarDecorator;
 import com.intellij.ui.table.JBTable;
 import org.jetbrains.annotations.Nls;
@@ -44,7 +45,7 @@ public class FixViewerSettingsConfigurable implements Configurable {
         versionTable = new JBTable(tableModel);
 
         // Setup file chooser descriptor
-        FileChooserDescriptor fileDescriptor = FileChooserDescriptorFactory.createSingleFileDescriptor()
+        FileChooserDescriptor fileDescriptor = FileChooserDescriptorFactory.createSingleLocalFileDescriptor()
                 .withTitle("Select Custom Dictionary")
                 .withDescription("Choose an XML or JSON dictionary file.");
 
@@ -69,7 +70,7 @@ public class FixViewerSettingsConfigurable implements Configurable {
                         JTextField versionField = new JTextField(currentVersion);
                         TextFieldWithBrowseButton fileField = new TextFieldWithBrowseButton();
                         fileField.setText(currentPath);
-                        fileField.addBrowseFolderListener("Select Custom Dictionary", null, project, fileDescriptor);
+                        fileField.addBrowseFolderListener(new TextBrowseFolderListener(fileDescriptor, project));
 
                         panel.add(new JLabel("FIX Version:"));
                         panel.add(versionField);


### PR DESCRIPTION
## Summary
- use `createSingleLocalFileDescriptor` instead of removed API
- switch to `TextBrowseFolderListener` with `addBrowseFolderListener`

## Testing
- `./gradlew testClasses --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684d8bb6d4a4832c9c517c54c9352b09