### PR TITLE
Add tree view for FIX messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ fields for different messages will be shown in the same row, making comparison e
   single character.
 - **Tooltips** showing tag descriptions (e.g., `35=8` → *Execution Report*)
 - **Transposed View** to make reading messages easier
+- **Tree View** to navigate message structure
 - **Message Hiding** in the transposed view for large message files
 - **Enumerated Values** suggested as items in the table view
 - **Override Dictionaries** with bespoke ones. Standard Quickfix dictionaries are used.
 
 ## Coming Soon
 
-- **Structural parsing and navigation** of FIX fields
 - **Repeating Groups** highlighting and structure
 
 ---

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
         testFramework(TestFrameworkType.Platform)
 
         implementation("org.json:json:20250517")
+        implementation("org.quickfixj:quickfixj-core:2.3.0")
     }
 }
 

--- a/src/main/java/com/rannett/fixplugin/ui/FixDualViewEditor.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixDualViewEditor.java
@@ -35,6 +35,7 @@ public class FixDualViewEditor extends UserDataHolderBase implements FileEditor 
     private final JPanel mainPanel;
     private final JTabbedPane tabbedPane;
     private final FixTransposedTablePanel tablePanel;
+    private final FixMessageTreePanel treePanel;
     private final Document document;
     private final VirtualFile file;
     private Integer pendingCaretOffset = null;
@@ -71,6 +72,9 @@ public class FixDualViewEditor extends UserDataHolderBase implements FileEditor 
             document.replaceString(lineStartOffset + valueStart, lineStartOffset + valueEnd, newValue);
         }), project);
         tabbedPane.addTab("Transposed Table", tablePanel);
+
+        treePanel = new FixMessageTreePanel(messages, project);
+        tabbedPane.addTab("Tree View", treePanel);
         mainPanel.add(tabbedPane, BorderLayout.CENTER);
 
         // Full rebuild and revalidation on document change
@@ -80,6 +84,7 @@ public class FixDualViewEditor extends UserDataHolderBase implements FileEditor 
                 SwingUtilities.invokeLater(() -> {
                     List<String> updatedMessages = Arrays.asList(document.getText().split("\\R+"));
                     tablePanel.updateTable(updatedMessages);
+                    treePanel.updateTree(updatedMessages);
                 });
             }
         });
@@ -164,7 +169,10 @@ public class FixDualViewEditor extends UserDataHolderBase implements FileEditor 
 
     @Override
     public @Nullable JComponent getPreferredFocusedComponent() {
-        return tabbedPane.getSelectedIndex() == 0 ? textEditor.getPreferredFocusedComponent() : tablePanel;
+        int index = tabbedPane.getSelectedIndex();
+        if (index == 0) return textEditor.getPreferredFocusedComponent();
+        if (index == 1) return tablePanel;
+        return treePanel;
     }
 
     @Override

--- a/src/main/java/com/rannett/fixplugin/ui/FixMessageTreePanel.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixMessageTreePanel.java
@@ -1,0 +1,140 @@
+package com.rannett.fixplugin.ui;
+
+import com.intellij.openapi.project.Project;
+import com.rannett.fixplugin.settings.FixViewerSettingsState;
+import com.rannett.fixplugin.util.FixUtils;
+import org.jetbrains.annotations.NotNull;
+import quickfix.ConfigError;
+import quickfix.DataDictionary;
+import quickfix.Field;
+import quickfix.FieldMap;
+import quickfix.Group;
+import quickfix.Message;
+
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTree;
+import javax.swing.tree.DefaultMutableTreeNode;
+import java.awt.BorderLayout;
+import java.io.File;
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Panel displaying FIX messages in a tree structure using the hierarchy
+ * defined in the FIX dictionary.
+ */
+public class FixMessageTreePanel extends JPanel {
+
+    private JTree tree;
+    private String fixVersion;
+    private final Project project;
+
+    public FixMessageTreePanel(List<String> fixMessages, Project project) {
+        super(new BorderLayout());
+        this.project = project;
+        buildTree(fixMessages);
+    }
+
+    public void updateTree(List<String> fixMessages) {
+        buildTree(fixMessages);
+    }
+
+    private void buildTree(List<String> fixMessages) {
+        DefaultMutableTreeNode root = new DefaultMutableTreeNode("Messages");
+
+        fixVersion = detectFixVersion(fixMessages.isEmpty() ? "" : fixMessages.get(0));
+        if (fixVersion == null) fixVersion = "FIX.4.2";
+
+        DataDictionary dd = loadDataDictionary(fixVersion);
+
+        int i = 1;
+        for (String message : fixMessages) {
+            message = message.trim();
+            if (message.isEmpty() || message.startsWith("#")) continue;
+            String msgId = "Message " + i++;
+            DefaultMutableTreeNode msgNode = new DefaultMutableTreeNode(msgId);
+            try {
+                Message qfMsg = new Message();
+                qfMsg.fromString(message, dd, true);
+
+                DefaultMutableTreeNode headerNode = new DefaultMutableTreeNode("Header");
+                buildNodes(qfMsg.getHeader(), headerNode, dd);
+                msgNode.add(headerNode);
+
+                DefaultMutableTreeNode bodyNode = new DefaultMutableTreeNode("Body");
+                buildNodes(qfMsg, bodyNode, dd);
+                msgNode.add(bodyNode);
+
+                DefaultMutableTreeNode trailerNode = new DefaultMutableTreeNode("Trailer");
+                buildNodes(qfMsg.getTrailer(), trailerNode, dd);
+                msgNode.add(trailerNode);
+
+            } catch (Exception e) {
+                msgNode.add(new DefaultMutableTreeNode("Parse error"));
+            }
+            root.add(msgNode);
+        }
+
+        tree = new JTree(root);
+        tree.setRootVisible(false);
+
+        removeAll();
+        add(new JScrollPane(tree), BorderLayout.CENTER);
+        revalidate();
+    }
+
+    private void buildNodes(FieldMap map, DefaultMutableTreeNode parent, DataDictionary dd) {
+        Iterator<Field<?>> fieldIt = map.iterator();
+        while (fieldIt.hasNext()) {
+            Field<?> field = fieldIt.next();
+            int tag = field.getTag();
+            String name = dd.getFieldName(tag);
+            String value = String.valueOf(field.getObject());
+            parent.add(new DefaultMutableTreeNode(tag + "=" + value + (name != null ? " (" + name + ")" : "")));
+        }
+
+        Iterator<Integer> groupKeys = map.groupKeyIterator();
+        while (groupKeys.hasNext()) {
+            int groupTag = groupKeys.next();
+            List<Group> groups = map.getGroups(groupTag);
+            String groupName = dd.getFieldName(groupTag);
+            int idx = 1;
+            for (Group g : groups) {
+                DefaultMutableTreeNode groupNode = new DefaultMutableTreeNode(
+                        (groupName != null ? groupName : groupTag) + " [" + idx++ + "]");
+                buildNodes(g, groupNode, dd);
+                parent.add(groupNode);
+            }
+        }
+    }
+
+    private String detectFixVersion(String message) {
+        return FixUtils.extractFixVersion(message).orElse(null);
+    }
+
+    private DataDictionary loadDataDictionary(@NotNull String version) {
+        FixViewerSettingsState settings = FixViewerSettingsState.getInstance(project);
+        String customPath = settings.getCustomDictionaryPath(version);
+        try {
+            if (customPath != null && !customPath.isEmpty()) {
+                return new DataDictionary(new File(customPath).getAbsolutePath());
+            }
+            String resourcePath = "/dictionaries/" + version + ".xml";
+            InputStream stream = FixMessageTreePanel.class.getResourceAsStream(resourcePath);
+            if (stream != null) {
+                return new DataDictionary(stream);
+            }
+            return new DataDictionary(version);
+        } catch (ConfigError e) {
+            throw new RuntimeException("Failed to load dictionary for " + version, e);
+        }
+    }
+
+    public JComponent getTreeComponent() {
+        return tree;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add QuickFIX/J dependency
- introduce `FixMessageTreePanel` for tree visualization of messages
- integrate new panel as a tab in `FixDualViewEditor`
- document new feature in README

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation matching 17)*

------
https://chatgpt.com/codex/tasks/task_e_684d9a318740832c80f2cf18f65634aa