### PR TITLE
Fix doc provider scope and NPE

### DIFF
--- a/src/main/java/com/rannett/fixplugin/FixDocumentationProvider.java
+++ b/src/main/java/com/rannett/fixplugin/FixDocumentationProvider.java
@@ -97,6 +97,10 @@ public class FixDocumentationProvider implements DocumentationProvider {
     }
 
     private String getOrComputeVersion(PsiFile file) {
+        if (file == null) {
+            return null;
+        }
+
         String cachedVersion = file.getUserData(FIX_VERSION_KEY);
         if (cachedVersion != null) {
             return cachedVersion;

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -37,7 +37,7 @@
         <annotator language="Fix" implementationClass="com.rannett.fixplugin.annotator.FixInvalidCharAnnotator"/>
         <annotator language="Fix" implementationClass="com.rannett.fixplugin.annotator.FixCheckTypeAnnotator"/>
 
-        <documentationProvider implementation="com.rannett.fixplugin.FixDocumentationProvider"/>
+        <documentationProvider language="Fix" implementation="com.rannett.fixplugin.FixDocumentationProvider"/>
 
         <fileEditorProvider implementation="com.rannett.fixplugin.ui.FixDualViewEditorProvider"/>
 


### PR DESCRIPTION
## Summary
- avoid NullPointerException in FixDocumentationProvider by handling null PsiFile
- restrict documentationProvider extension to only handle Fix language

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68528d7b7b80832ca166e84a0ce00c28