### PR TITLE
Add diff support for FIX messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # fix-plugin2 Changelog
 
 ## [Unreleased]
+### Added
+- Side-by-side comparison of FIX messages using IntelliJ diff viewer
 
 ## [0.0.1]
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ fields for different messages will be shown in the same row, making comparison e
 - **Message Hiding** in the transposed view for large message files
 - **Enumerated Values** suggested as items in the table view
 - **Override Dictionaries** with bespoke ones. Standard Quickfix dictionaries are used.
+- **Side-by-side diff viewer** for comparing two messages
 
 ## Coming Soon
 

--- a/src/test/java/com/rannett/fixplugin/ui/FixTransposedTablePanelTest.java
+++ b/src/test/java/com/rannett/fixplugin/ui/FixTransposedTablePanelTest.java
@@ -1,0 +1,18 @@
+package com.rannett.fixplugin.ui;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class FixTransposedTablePanelTest {
+    @Test
+    public void testGetMessageText() {
+        List<String> messages = List.of("8=FIX.4.4|35=A|10=111|", "8=FIX.4.4|35=B|10=222|");
+        FixTransposedTablePanel panel = new FixTransposedTablePanel(messages, (id, tag, occ, val) -> {}, null);
+        assertEquals("8=FIX.4.4|35=A|10=111|", panel.getMessageText("Message 1"));
+        assertEquals("8=FIX.4.4|35=B|10=222|", panel.getMessageText("Message 2"));
+        assertEquals("", panel.getMessageText("Message 3"));
+    }
+}


### PR DESCRIPTION
## Summary
- allow comparing two FIX messages using DiffManager
- store messages and Project in `FixTransposedTablePanel`
- expose `getMessageText` helper
- add `Compare With...` menu option in the header context menu
- document diff viewer in README and CHANGELOG
- test message retrieval helper

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685d4030b6c8832c80df2d1ca51a9eeb