### PR TITLE
Show enum values in tree view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Display enum descriptions alongside field names in the tree view
+
 ## [0.0.1]
 
 ### Added

--- a/src/main/java/com/rannett/fixplugin/ui/FixMessageTreePanel.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixMessageTreePanel.java
@@ -90,7 +90,18 @@ public class FixMessageTreePanel extends JPanel {
             int tag = field.getTag();
             String name = dd.getFieldName(tag);
             String value = String.valueOf(field.getObject());
-            parent.add(new DefaultMutableTreeNode(tag + "=" + value + (name != null ? " (" + name + ")" : "")));
+            String enumName = dd.getValueName(tag, value);
+
+            StringBuilder label = new StringBuilder();
+            label.append(tag).append("=").append(value);
+            if (name != null) {
+                label.append(" (").append(name);
+                if (enumName != null) {
+                    label.append("=").append(enumName);
+                }
+                label.append(")");
+            }
+            parent.add(new DefaultMutableTreeNode(label.toString()));
         }
 
         Iterator<Integer> groupKeys = map.groupKeyIterator();


### PR DESCRIPTION
## Summary
- display enum descriptions in the tree view
- update changelog

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685d3ff12380832c92c19c9e64b4cb9d