### PR TITLE
Migrate to DocumentationTarget API

### DIFF
--- a/src/main/java/com/rannett/fixplugin/FixDocumentationTarget.java
+++ b/src/main/java/com/rannett/fixplugin/FixDocumentationTarget.java
@@ -1,0 +1,67 @@
+package com.rannett.fixplugin;
+
+import com.intellij.lang.documentation.DocumentationImageResolver;
+import com.intellij.lang.documentation.DocumentationProvider;
+import com.intellij.model.Pointer;
+import com.intellij.openapi.project.Project;
+import com.intellij.pom.Navigatable;
+import com.intellij.platform.backend.documentation.DocumentationContent;
+import com.intellij.platform.backend.documentation.DocumentationResult;
+import com.intellij.platform.backend.documentation.DocumentationTarget;
+import com.intellij.platform.backend.presentation.TargetPresentation;
+import com.intellij.platform.backend.presentation.TargetPresentationBuilder;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.SmartPointerManager;
+import com.intellij.psi.SmartPsiElementPointer;
+import com.intellij.util.concurrency.annotations.RequiresReadLock;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * DocumentationTarget implementation for FIX elements.
+ */
+public class FixDocumentationTarget implements DocumentationTarget {
+    private final @NotNull PsiElement element;
+    private final @NotNull Project project;
+
+    public FixDocumentationTarget(@NotNull PsiElement element) {
+        this.element = element;
+        this.project = element.getProject();
+    }
+
+    @Override
+    public @NotNull Pointer<? extends DocumentationTarget> createPointer() {
+        SmartPsiElementPointer<PsiElement> pointer = SmartPointerManager.getInstance(project)
+                .createSmartPsiElementPointer(element);
+        return () -> {
+            PsiElement psi = pointer.getElement();
+            return psi == null ? null : new FixDocumentationTarget(psi);
+        };
+    }
+
+    @Override
+    public @NotNull TargetPresentation computePresentation() {
+        return TargetPresentation.builder(element.getText()).presentation();
+    }
+
+    @Override
+    public @Nullable Navigatable getNavigatable() {
+        return element instanceof Navigatable ? (Navigatable) element : null;
+    }
+
+    @Override
+    public @Nullable String computeDocumentationHint() {
+        return element.getText();
+    }
+
+    @Override
+    @RequiresReadLock
+    public @Nullable DocumentationResult computeDocumentation() {
+        String html = new FixDocumentationProvider().generateDoc(element, element);
+        if (html == null) {
+            return null;
+        }
+        DocumentationContent content = DocumentationContent.content(html);
+        return DocumentationResult.documentation(content);
+    }
+}

--- a/src/main/java/com/rannett/fixplugin/FixDocumentationTarget.java
+++ b/src/main/java/com/rannett/fixplugin/FixDocumentationTarget.java
@@ -1,7 +1,5 @@
 package com.rannett.fixplugin;
 
-import com.intellij.lang.documentation.DocumentationImageResolver;
-import com.intellij.lang.documentation.DocumentationProvider;
 import com.intellij.model.Pointer;
 import com.intellij.openapi.project.Project;
 import com.intellij.pom.Navigatable;

--- a/src/main/java/com/rannett/fixplugin/FixDocumentationTargetProvider.java
+++ b/src/main/java/com/rannett/fixplugin/FixDocumentationTargetProvider.java
@@ -1,0 +1,34 @@
+package com.rannett.fixplugin;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.util.PsiUtilCore;
+import com.intellij.util.concurrency.annotations.RequiresReadLock;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Provider that creates FixDocumentationTarget instances.
+ */
+public class FixDocumentationTargetProvider implements com.intellij.platform.backend.documentation.DocumentationTargetProvider {
+
+    @Override
+    @RequiresReadLock
+    public @NotNull List<? extends com.intellij.platform.backend.documentation.DocumentationTarget> documentationTargets(@NotNull PsiFile file, int offset) {
+        PsiElement element = file.findElementAt(offset);
+        if (element == null) return Collections.emptyList();
+
+        // use the same logic as FixDocumentationProvider#getCustomDocumentationElement
+        var elementType = PsiUtilCore.getElementType(element);
+        if (elementType == com.rannett.fixplugin.psi.FixTypes.TAG || elementType == com.rannett.fixplugin.psi.FixTypes.VALUE) {
+            return List.of(new FixDocumentationTarget(element));
+        }
+        String text = element.getText();
+        if (text.matches("\\d+.*") || text.matches("[A-Z]+")) {
+            return List.of(new FixDocumentationTarget(element));
+        }
+        return Collections.emptyList();
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -37,8 +37,8 @@
         <annotator language="Fix" implementationClass="com.rannett.fixplugin.annotator.FixInvalidCharAnnotator"/>
         <annotator language="Fix" implementationClass="com.rannett.fixplugin.annotator.FixCheckTypeAnnotator"/>
 
-        <lang.documentationProvider language="Fix"
-                                    implementationClass="com.rannett.fixplugin.FixDocumentationProvider"/>
+        <documentationTargetProvider language="Fix"
+                                    implementationClass="com.rannett.fixplugin.FixDocumentationTargetProvider"/>
 
         <fileEditorProvider implementation="com.rannett.fixplugin.ui.FixDualViewEditorProvider"/>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -38,7 +38,7 @@
         <annotator language="Fix" implementationClass="com.rannett.fixplugin.annotator.FixCheckTypeAnnotator"/>
 
         <documentationTargetProvider language="Fix"
-                                    implementationClass="com.rannett.fixplugin.FixDocumentationTargetProvider"/>
+                                    implementation="com.rannett.fixplugin.FixDocumentationTargetProvider"/>
 
         <fileEditorProvider implementation="com.rannett.fixplugin.ui.FixDualViewEditorProvider"/>
 


### PR DESCRIPTION
## Summary
- implement `FixDocumentationTarget` using new DocumentationTarget API
- provide `FixDocumentationTargetProvider` extension
- register provider in plugin.xml

## Testing
- `./gradlew build -x test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685d3fe2ec4c832ca8dc17a6150a700a