### PR TITLE
Add tag filtering for transposed table

### DIFF
--- a/src/main/java/com/rannett/fixplugin/ui/FixTransposedTablePanel.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixTransposedTablePanel.java
@@ -172,6 +172,13 @@ public class FixTransposedTablePanel extends JPanel {
         }
     }
 
+    public void resetFilters() {
+        filteredTags.clear();
+        sorter.setRowFilter(null);
+        sorter.setSortKeys(null);
+        sorter.sort();
+    }
+
     public void setOnCellSelected(Runnable callback) {
         this.onCellSelectedCallback = callback;
     }
@@ -271,6 +278,10 @@ public class FixTransposedTablePanel extends JPanel {
         JMenuItem filterTags = new JMenuItem("Filter Tags...");
         filterTags.addActionListener(ae -> showTagFilterDialog());
         menu.add(filterTags);
+
+        JMenuItem resetFilters = new JMenuItem("Reset Filters");
+        resetFilters.addActionListener(ae -> resetFilters());
+        menu.add(resetFilters);
 
         if (columnIndex >= 2) {
             JMenuItem compareWith = new JMenuItem("Compare With...");

--- a/src/main/java/com/rannett/fixplugin/ui/FixTransposedTablePanel.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixTransposedTablePanel.java
@@ -27,6 +27,8 @@ import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.JTableHeader;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
+import javax.swing.table.TableRowSorter;
+import javax.swing.RowFilter;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.event.MouseAdapter;
@@ -36,6 +38,8 @@ import java.util.Enumeration;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.LinkedHashSet;
 
 public class FixTransposedTablePanel extends JPanel {
     private final FixTransposedTableModel model;
@@ -44,6 +48,8 @@ public class FixTransposedTablePanel extends JPanel {
     private final List<TableColumn> allColumns = new ArrayList<>();
     private final Project project;
     private List<String> messages;
+    private final TableRowSorter<FixTransposedTableModel> sorter;
+    private Set<String> filteredTags = new LinkedHashSet<>();
 
     public FixTransposedTablePanel(List<String> fixMessages, FixTransposedTableModel.DocumentUpdater updater, Project project) {
         super(new BorderLayout());
@@ -52,6 +58,8 @@ public class FixTransposedTablePanel extends JPanel {
         model = new FixTransposedTableModel(fixMessages, updater, project);
         table = new JBTable(model);
         table.setFillsViewportHeight(true);
+        sorter = new TableRowSorter<>(model);
+        table.setRowSorter(sorter);
 
         // Custom renderer to show value + description
         table.setDefaultRenderer(Object.class, new DefaultTableCellRenderer() {
@@ -145,6 +153,23 @@ public class FixTransposedTablePanel extends JPanel {
     public void updateTable(List<String> fixMessages) {
         this.messages = new ArrayList<>(fixMessages);
         model.updateMessages(fixMessages);
+        applyTagFilter(filteredTags);
+    }
+
+    public void applyTagFilter(Set<String> tags) {
+        filteredTags = new LinkedHashSet<>(tags);
+        if (filteredTags.isEmpty()) {
+            sorter.setRowFilter(null);
+        } else {
+            sorter.setRowFilter(new RowFilter<>() {
+                @Override
+                public boolean include(Entry<? extends FixTransposedTableModel, ? extends Integer> entry) {
+                    String tag = entry.getStringValue(0);
+                    String name = entry.getStringValue(1);
+                    return filteredTags.contains(tag) || (name != null && filteredTags.contains(name));
+                }
+            });
+        }
     }
 
     public void setOnCellSelected(Runnable callback) {
@@ -175,12 +200,33 @@ public class FixTransposedTablePanel extends JPanel {
         }
     }
 
+    public Set<String> getAllTags() {
+        Set<String> tags = new LinkedHashSet<>();
+        for (int i = 0; i < model.getRowCount(); i++) {
+            tags.add(model.getTagAtRow(i));
+        }
+        return tags;
+    }
+
     public void highlightTagCell(String tag, String messageId) {
         int row = model.getRowForTag(tag);
         int col = model.getColumnForMessageId(messageId);
-        if (row >= 0 && col >= 0) table.changeSelection(row, col, false, false);
-        else if (row >= 0) table.setRowSelectionInterval(row, row);
-        else table.clearSelection();
+        if (row >= 0 && col >= 0) {
+            int viewRow = table.convertRowIndexToView(row);
+            int viewCol = table.convertColumnIndexToView(col);
+            if (viewRow >= 0 && viewCol >= 0) {
+                table.changeSelection(viewRow, viewCol, false, false);
+                return;
+            }
+        }
+        if (row >= 0) {
+            int viewRow = table.convertRowIndexToView(row);
+            if (viewRow >= 0) {
+                table.setRowSelectionInterval(viewRow, viewRow);
+                return;
+            }
+        }
+        table.clearSelection();
     }
 
     public void clearHighlight() {
@@ -221,6 +267,10 @@ public class FixTransposedTablePanel extends JPanel {
         JMenuItem showAllColumns = new JMenuItem("Show All Columns");
         showAllColumns.addActionListener(ae -> showAllColumns());
         menu.add(showAllColumns);
+
+        JMenuItem filterTags = new JMenuItem("Filter Tags...");
+        filterTags.addActionListener(ae -> showTagFilterDialog());
+        menu.add(filterTags);
 
         if (columnIndex >= 2) {
             JMenuItem compareWith = new JMenuItem("Compare With...");
@@ -312,6 +362,14 @@ public class FixTransposedTablePanel extends JPanel {
         var content2 = contentFactory.create(project, text2, FixFileType.INSTANCE);
         var request = new SimpleDiffRequest("Compare FIX Messages", content1, content2, firstId, secondId);
         DiffManager.getInstance().showDiff(project, request);
+    }
+
+    private void showTagFilterDialog() {
+        Set<String> allTags = getAllTags();
+        TagFilterDialog dialog = new TagFilterDialog(project, allTags, filteredTags, model.getFixVersion());
+        if (dialog.showAndGet()) {
+            applyTagFilter(dialog.getSelectedTags());
+        }
     }
 
     private boolean isColumnMissing(TableColumnModel columnModel, TableColumn column) {

--- a/src/main/java/com/rannett/fixplugin/ui/TagFilterDialog.java
+++ b/src/main/java/com/rannett/fixplugin/ui/TagFilterDialog.java
@@ -1,0 +1,63 @@
+package com.rannett.fixplugin.ui;
+
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.openapi.project.Project;
+import com.rannett.fixplugin.dictionary.FixDictionaryCache;
+import com.rannett.fixplugin.dictionary.FixTagDictionary;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.util.*;
+
+public class TagFilterDialog extends DialogWrapper {
+    private final JList<String> list;
+    private final Map<String, String> displayToTagMap = new LinkedHashMap<>();
+
+    public TagFilterDialog(@Nullable Project project,
+                           Collection<String> tags,
+                           Collection<String> initiallySelected,
+                           String fixVersion) {
+        super(project, true);
+        FixTagDictionary dict = null;
+        if (project != null) {
+            dict = project.getService(FixDictionaryCache.class).getDictionary(fixVersion);
+        }
+        for (String tag : tags) {
+            String name = dict != null ? dict.getTagName(tag) : null;
+            String display = name != null && !name.isEmpty() ? tag + " (" + name + ")" : tag;
+            displayToTagMap.put(display, tag);
+        }
+        list = new JList<>(displayToTagMap.keySet().toArray(new String[0]));
+        list.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
+
+        if (initiallySelected != null) {
+            java.util.List<Integer> indices = new ArrayList<>();
+            int i = 0;
+            for (String display : displayToTagMap.keySet()) {
+                if (initiallySelected.contains(displayToTagMap.get(display))) {
+                    indices.add(i);
+                }
+                i++;
+            }
+            int[] idxArr = indices.stream().mapToInt(Integer::intValue).toArray();
+            list.setSelectedIndices(idxArr);
+        }
+
+        init();
+        setTitle("Filter Tags");
+    }
+
+    @Override
+    protected @Nullable JComponent createCenterPanel() {
+        return new JScrollPane(list);
+    }
+
+    public Set<String> getSelectedTags() {
+        Set<String> sel = new LinkedHashSet<>();
+        for (String display : list.getSelectedValuesList()) {
+            sel.add(displayToTagMap.get(display));
+        }
+        return sel;
+    }
+}

--- a/src/main/java/com/rannett/fixplugin/ui/TagFilterDialog.java
+++ b/src/main/java/com/rannett/fixplugin/ui/TagFilterDialog.java
@@ -4,15 +4,20 @@ import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.project.Project;
 import com.rannett.fixplugin.dictionary.FixDictionaryCache;
 import com.rannett.fixplugin.dictionary.FixTagDictionary;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import java.awt.BorderLayout;
 import java.util.*;
 
 public class TagFilterDialog extends DialogWrapper {
-    private final JList<String> list;
+    private final DefaultListModel<String> model = new DefaultListModel<>();
+    private final JList<String> list = new JList<>(model);
+    private final JTextField searchField = new JTextField();
     private final Map<String, String> displayToTagMap = new LinkedHashMap<>();
+    private final java.util.List<String> allDisplays = new ArrayList<>();
 
     public TagFilterDialog(@Nullable Project project,
                            Collection<String> tags,
@@ -27,14 +32,15 @@ public class TagFilterDialog extends DialogWrapper {
             String name = dict != null ? dict.getTagName(tag) : null;
             String display = name != null && !name.isEmpty() ? tag + " (" + name + ")" : tag;
             displayToTagMap.put(display, tag);
+            allDisplays.add(display);
+            model.addElement(display);
         }
-        list = new JList<>(displayToTagMap.keySet().toArray(new String[0]));
         list.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
 
         if (initiallySelected != null) {
             java.util.List<Integer> indices = new ArrayList<>();
             int i = 0;
-            for (String display : displayToTagMap.keySet()) {
+            for (String display : allDisplays) {
                 if (initiallySelected.contains(displayToTagMap.get(display))) {
                     indices.add(i);
                 }
@@ -44,13 +50,52 @@ public class TagFilterDialog extends DialogWrapper {
             list.setSelectedIndices(idxArr);
         }
 
+        searchField.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                filterList();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                filterList();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                filterList();
+            }
+        });
+
         init();
         setTitle("Filter Tags");
     }
 
+    private void filterList() {
+        String term = searchField.getText().trim().toLowerCase();
+        java.util.List<String> selected = new ArrayList<>(getSelectedTags());
+        model.clear();
+        java.util.List<Integer> indices = new ArrayList<>();
+        int i = 0;
+        for (String display : allDisplays) {
+            if (term.isEmpty() || display.toLowerCase().contains(term)) {
+                model.addElement(display);
+                if (selected.contains(displayToTagMap.get(display))) {
+                    indices.add(i);
+                }
+                i++;
+            }
+        }
+        int[] idxArr = indices.stream().mapToInt(Integer::intValue).toArray();
+        list.setSelectedIndices(idxArr);
+    }
+
     @Override
     protected @Nullable JComponent createCenterPanel() {
-        return new JScrollPane(list);
+        JPanel panel = new JPanel(new BorderLayout());
+        panel.add(searchField, BorderLayout.NORTH);
+        panel.add(new JScrollPane(list), BorderLayout.CENTER);
+        return panel;
     }
 
     public Set<String> getSelectedTags() {


### PR DESCRIPTION
## Summary
- add `TagFilterDialog` to choose tags or tag names
- support filtering rows in `FixTransposedTablePanel`
- preserve highlight and filtering when table updates

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685d63792588832c85aff95b91344145