### PR TITLE
Enable FIX language injection within code strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # fix-plugin2 Changelog
 
 ## [Unreleased]
+- Added language injection for FIX messages embedded in code strings
 
 ## [0.0.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## [Unreleased]
 - Added language injection for FIX messages embedded in code strings
+- Added tests for language injection
 
 ## [0.0.1]
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ fields for different messages will be shown in the same row, making comparison e
 - **Enumerated Values** suggested as items in the table view
 - **Override Dictionaries** with bespoke ones. Standard Quickfix dictionaries are used.
 - **Side-by-side diff viewer** for comparing two messages
+- **Language injection** for FIX messages embedded in code strings
 
 ## Coming Soon
 

--- a/src/main/java/com/rannett/fixplugin/injection/FixStringLanguageInjector.java
+++ b/src/main/java/com/rannett/fixplugin/injection/FixStringLanguageInjector.java
@@ -18,10 +18,10 @@ import java.util.List;
  */
 public class FixStringLanguageInjector implements MultiHostInjector {
 
-    @Override
     /**
      * Inject the Fix language into a string literal if the text resembles a FIX message.
      */
+    @Override
     public void getLanguagesToInject(@NotNull MultiHostRegistrar registrar, @NotNull PsiElement context) {
         if (!(context instanceof PsiLanguageInjectionHost host) || !host.isValidHost()) {
             return;
@@ -35,7 +35,7 @@ public class FixStringLanguageInjector implements MultiHostInjector {
         // Strip common quoting characters
         char first = text.charAt(0);
         char last = text.charAt(text.length() - 1);
-        if ((first == '"' || first == '\'') && first == last && text.length() > 1) {
+        if ((first == '"' || first == '\'') && first == last ) {
             text = text.substring(1, text.length() - 1);
         }
 
@@ -55,11 +55,11 @@ public class FixStringLanguageInjector implements MultiHostInjector {
         registrar.doneInjecting();
     }
 
-    @Override
     /**
      * Specify that all {@link PsiLanguageInjectionHost} elements may be processed
      * for potential injection.
      */
+    @Override
     public @NotNull List<Class<? extends PsiElement>> elementsToInjectIn() {
         return List.of(PsiLanguageInjectionHost.class);
     }

--- a/src/main/java/com/rannett/fixplugin/injection/FixStringLanguageInjector.java
+++ b/src/main/java/com/rannett/fixplugin/injection/FixStringLanguageInjector.java
@@ -1,0 +1,67 @@
+package com.rannett.fixplugin.injection;
+
+import com.intellij.lang.injection.MultiHostInjector;
+import com.intellij.lang.injection.MultiHostRegistrar;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiLanguageInjectionHost;
+import com.rannett.fixplugin.FixLanguage;
+import com.rannett.fixplugin.util.FixUtils;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * Injects the Fix language into string literals when they appear to contain
+ * FIX messages. This enables syntax highlighting and inspections for messages
+ * embedded directly in source code.
+ */
+public class FixStringLanguageInjector implements MultiHostInjector {
+
+    @Override
+    /**
+     * Inject the Fix language into a string literal if the text resembles a FIX message.
+     */
+    public void getLanguagesToInject(@NotNull MultiHostRegistrar registrar, @NotNull PsiElement context) {
+        if (!(context instanceof PsiLanguageInjectionHost host) || !host.isValidHost()) {
+            return;
+        }
+
+        String text = host.getText();
+        if (text == null || text.length() < 5) {
+            return;
+        }
+
+        // Strip common quoting characters
+        char first = text.charAt(0);
+        char last = text.charAt(text.length() - 1);
+        if ((first == '"' || first == '\'') && first == last && text.length() > 1) {
+            text = text.substring(1, text.length() - 1);
+        }
+
+        if (FixUtils.extractFixVersion(text).isEmpty()) {
+            return;
+        }
+
+        int startOffset = 0;
+        int endOffset = host.getTextLength();
+        if (host.getTextLength() > 1 && (first == '"' || first == '\'')) {
+            startOffset = 1;
+            endOffset = host.getTextLength() - 1;
+        }
+
+        registrar.startInjecting(FixLanguage.INSTANCE);
+        registrar.addPlace(null, null, host, new TextRange(startOffset, endOffset));
+        registrar.doneInjecting();
+    }
+
+    @Override
+    /**
+     * Specify that all {@link PsiLanguageInjectionHost} elements may be processed
+     * for potential injection.
+     */
+    public @NotNull List<Class<? extends PsiElement>> elementsToInjectIn() {
+        return List.of(PsiLanguageInjectionHost.class);
+    }
+}
+

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -42,6 +42,9 @@
 
         <fileEditorProvider implementation="com.rannett.fixplugin.ui.FixDualViewEditorProvider"/>
 
+        <multiHostInjector
+                implementation="com.rannett.fixplugin.injection.FixStringLanguageInjector"/>
+
     </extensions>
     <extensions defaultExtensionNs="com.intellij">
         <projectConfigurable

--- a/src/test/java/com/rannett/fixplugin/injection/FixStringLanguageInjectorTest.java
+++ b/src/test/java/com/rannett/fixplugin/injection/FixStringLanguageInjectorTest.java
@@ -1,0 +1,24 @@
+package com.rannett.fixplugin.injection;
+
+import com.intellij.lang.injection.InjectedLanguageManager;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+public class FixStringLanguageInjectorTest extends BasePlatformTestCase {
+
+    public void testInjectionOccursForFixString() {
+        String code = "class T { String msg = \"8=FIX.4.2|9=5|35=0|10=000|\"; }";
+        myFixture.configureByText("T.java", code);
+        int offset = myFixture.getFile().getText().indexOf("8=FIX.4.2") + 1;
+        assertNotNull(InjectedLanguageManager.getInstance(getProject())
+                .findInjectedElementAt(myFixture.getFile(), offset));
+    }
+
+    public void testNoInjectionForRegularString() {
+        String code = "class T { String msg = \"hello world\"; }";
+        myFixture.configureByText("T.java", code);
+        int offset = myFixture.getFile().getText().indexOf("hello world") + 1;
+        assertNull(InjectedLanguageManager.getInstance(getProject())
+                .findInjectedElementAt(myFixture.getFile(), offset));
+    }
+}
+


### PR DESCRIPTION
## Summary
- inject Fix language into string literals when they contain FIX messages
- register the injector in plugin.xml
- document the new feature and update changelog

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6865606e5930832cbf53055327023bd2