### PR TITLE
Add extended UTCTimestamp support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support for extended precision UTCTimestamps with optional trailing `Z`.
+
 ## [0.0.1]
 
 ### Added

--- a/src/main/java/com/rannett/fixplugin/util/FieldTypeValidator.java
+++ b/src/main/java/com/rannett/fixplugin/util/FieldTypeValidator.java
@@ -36,7 +36,7 @@ public class FieldTypeValidator {
                 return value.matches("^(\\d{4}(0[1-9]|1[0-2]))" +  // YYYYMM
                         "((0[1-9]|[12][0-9]|3[01])|(w[1-5]))?$");  // Optional DD or w1-w5
             case "UTCTIMESTAMP":
-                return value.matches("^\\d{8}-\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?$");
+                return value.matches("^\\d{8}-\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?[Zz]?$");
             case "UTCTIMEONLY":
                 return value.matches("^\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?$");
             case "UTCDATEONLY":

--- a/src/test/java/com/rannett/fixplugin/util/FieldTypeValidatorTest.java
+++ b/src/test/java/com/rannett/fixplugin/util/FieldTypeValidatorTest.java
@@ -89,6 +89,7 @@ public class FieldTypeValidatorTest {
     public void testValidUTCTimestamp() {
         assertTrue(FieldTypeValidator.isValueValidForType("UTCTimestamp", "20240531-15:20:30"));
         assertTrue(FieldTypeValidator.isValueValidForType("UTCTimestamp", "20240531-15:20:30.123"));
+        assertTrue(FieldTypeValidator.isValueValidForType("UTCTimestamp", "20241011-12:45:18.938000000Z"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- support fractional UTCTimestamp values up to nanoseconds with optional `Z`
- add regression test for UTCTimestamp with trailing `Z`
- document the new capability in the changelog

## Testing
- `./gradlew test --offline --no-daemon --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_6867e5f7e95c832ca6f66a5afe15f9df