### PR TITLE
Handle XmlData linefeeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 - Added language injection for FIX messages embedded in code strings
 - Added tests for language injection
 
+### Fixed
+
+- Invalid character warnings are no longer reported for FpML text in XmlData or
+  EncodedSecurityDesc fields.
+
 ### Added
 
 - Support for extended precision UTCTimestamps with optional trailing `Z`.

--- a/src/main/java/com/rannett/fixplugin/annotator/FixInvalidCharAnnotator.java
+++ b/src/main/java/com/rannett/fixplugin/annotator/FixInvalidCharAnnotator.java
@@ -7,11 +7,21 @@ import com.intellij.openapi.editor.DefaultLanguageHighlighterColors;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.rannett.fixplugin.psi.FixField;
 import com.rannett.fixplugin.psi.FixTypes;
+import quickfix.field.EncodedSecurityDesc;
+import quickfix.field.XmlData;
 import org.jetbrains.annotations.NotNull;
 
 public class FixInvalidCharAnnotator implements Annotator {
 
+    /**
+     * Annotates invalid characters within FIX message elements.
+     *
+     * @param element the PSI element to check
+     * @param holder  the annotation holder used to report problems
+     */
     @Override
     public void annotate(@NotNull PsiElement element, @NotNull AnnotationHolder holder) {
 
@@ -22,6 +32,15 @@ public class FixInvalidCharAnnotator implements Annotator {
                 type != FixTypes.SEPARATOR &&
                 type != FixTypes.FIELD_SEPARATOR) {
             return;
+        }
+
+        FixField field = PsiTreeUtil.getParentOfType(element, FixField.class);
+        if (type == FixTypes.VALUE && field != null) {
+            String tag = field.getTag();
+            if (String.valueOf(XmlData.FIELD).equals(tag) ||
+                    String.valueOf(EncodedSecurityDesc.FIELD).equals(tag)) {
+                return;
+            }
         }
 
         String text = element.getText();

--- a/src/test/java/com/rannett/fixplugin/annotator/FixInvalidCharAnnotatorTest.java
+++ b/src/test/java/com/rannett/fixplugin/annotator/FixInvalidCharAnnotatorTest.java
@@ -1,0 +1,30 @@
+package com.rannett.fixplugin.annotator;
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+import static org.junit.Assert.assertFalse;
+
+public class FixInvalidCharAnnotatorTest extends BasePlatformTestCase {
+
+    public void testFpmlXmlDataNotFlagged() {
+        String xml = "<note>\\\ntext</note>";
+        String message = "8=FIX.4.4|35=D|213=" + xml + "|10=000|";
+        myFixture.configureByText("msg.fix", message);
+        var infos = myFixture.doHighlighting();
+        assertFalse(infos.stream().anyMatch(i -> {
+            String desc = i.getDescription();
+            return desc != null && desc.startsWith("Invalid FIX character");
+        }));
+    }
+
+    public void testFpmlEncodedSecurityDescNotFlagged() {
+        String xml = "<note>\\\ntext</note>";
+        String message = "8=FIX.4.4|35=D|351=" + xml + "|10=000|";
+        myFixture.configureByText("msg.fix", message);
+        var infos = myFixture.doHighlighting();
+        assertFalse(infos.stream().anyMatch(i -> {
+            String desc = i.getDescription();
+            return desc != null && desc.startsWith("Invalid FIX character");
+        }));
+    }
+}


### PR DESCRIPTION
## Summary
- avoid invalid char annotations for XmlData and EncodedSecurityDesc values
- test that line feeds in those fields are allowed
- document change in CHANGELOG

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6869560fbe20832cb107e98af47da1e8