### PR TITLE
Improve test coverage for lexer and dictionary cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 - Added language injection for FIX messages embedded in code strings
 - Added tests for language injection
+- Added tests for dictionary caching and additional lexer scenarios
 
 ### Added
 

--- a/src/test/java/com/rannett/fixplugin/FixLexerAdditionalTest.java
+++ b/src/test/java/com/rannett/fixplugin/FixLexerAdditionalTest.java
@@ -1,0 +1,67 @@
+package com.rannett.fixplugin;
+
+import com.rannett.fixplugin.psi.FixTypes;
+import com.intellij.psi.TokenType;
+import com.intellij.psi.tree.IElementType;
+import org.junit.Test;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class FixLexerAdditionalTest {
+
+    @Test
+    public void testLexerTokenSequence() throws Exception {
+        String msg = "35=A|10=999|";
+        FixLexer lexer = new FixLexer(new StringReader(msg));
+        lexer.reset(msg, 0, msg.length(), FixLexer.YYINITIAL);
+
+        List<IElementType> tokens = new ArrayList<>();
+        IElementType token;
+        while ((token = lexer.advance()) != null) {
+            tokens.add(token);
+        }
+
+        List<IElementType> expected = List.of(
+                FixTypes.TAG,
+                FixTypes.SEPARATOR,
+                FixTypes.VALUE,
+                FixTypes.FIELD_SEPARATOR,
+                FixTypes.TAG,
+                FixTypes.SEPARATOR,
+                FixTypes.VALUE,
+                FixTypes.FIELD_SEPARATOR
+        );
+        assertEquals(expected, tokens);
+    }
+
+    @Test
+    public void testLexerHandlesCommentsAndWhitespace() throws Exception {
+        String msg = "#comment\n8=FIX.4.2|10=000|";
+        FixLexer lexer = new FixLexer(new StringReader(msg));
+        lexer.reset(msg, 0, msg.length(), FixLexer.YYINITIAL);
+
+        List<IElementType> tokens = new ArrayList<>();
+        IElementType token;
+        while ((token = lexer.advance()) != null) {
+            tokens.add(token);
+        }
+
+        List<IElementType> expected = List.of(
+                FixTypes.TAG,          // comment returned as TAG
+                TokenType.WHITE_SPACE, // newline
+                FixTypes.TAG,
+                FixTypes.SEPARATOR,
+                FixTypes.VALUE,
+                FixTypes.FIELD_SEPARATOR,
+                FixTypes.TAG,
+                FixTypes.SEPARATOR,
+                FixTypes.VALUE,
+                FixTypes.FIELD_SEPARATOR
+        );
+        assertEquals(expected, tokens);
+    }
+}

--- a/src/test/java/com/rannett/fixplugin/dictionary/FixDictionaryCacheTest.java
+++ b/src/test/java/com/rannett/fixplugin/dictionary/FixDictionaryCacheTest.java
@@ -1,0 +1,41 @@
+package com.rannett.fixplugin.dictionary;
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import com.rannett.fixplugin.settings.FixViewerSettingsState;
+
+import java.io.File;
+import java.nio.file.Files;
+
+public class FixDictionaryCacheTest extends BasePlatformTestCase {
+
+    public void testCustomPathIsUsed() throws Exception {
+        File file = File.createTempFile("dict", ".xml");
+        Files.writeString(file.toPath(), "<dictionary>\n<field number=\"1\" name=\"One\" type=\"STRING\"/>\n</dictionary>");
+
+        FixViewerSettingsState settings = FixViewerSettingsState.getInstance(getProject());
+        settings.getCustomDictionaryPaths().put("FIX.4.2", file.getAbsolutePath());
+
+        FixDictionaryCache cache = new FixDictionaryCache(getProject());
+        FixTagDictionary dict = cache.getDictionary("FIX.4.2");
+        assertEquals("One", dict.getTagName("1"));
+    }
+
+    public void testDictionaryIsCached() throws Exception {
+        File file1 = File.createTempFile("dict1", ".xml");
+        Files.writeString(file1.toPath(), "<dictionary>\n<field number=\"1\" name=\"First\" type=\"STRING\"/>\n</dictionary>");
+        FixViewerSettingsState settings = FixViewerSettingsState.getInstance(getProject());
+        settings.getCustomDictionaryPaths().put("FIX.4.3", file1.getAbsolutePath());
+
+        FixDictionaryCache cache = new FixDictionaryCache(getProject());
+        FixTagDictionary first = cache.getDictionary("FIX.4.3");
+        assertEquals("First", first.getTagName("1"));
+
+        File file2 = File.createTempFile("dict2", ".xml");
+        Files.writeString(file2.toPath(), "<dictionary>\n<field number=\"1\" name=\"Second\" type=\"STRING\"/>\n</dictionary>");
+        settings.getCustomDictionaryPaths().put("FIX.4.3", file2.getAbsolutePath());
+
+        FixTagDictionary second = cache.getDictionary("FIX.4.3");
+        assertSame(first, second);
+        assertEquals("First", second.getTagName("1"));
+    }
+}


### PR DESCRIPTION
## Summary
- add lexer tokenization tests
- test FixDictionaryCache custom paths and caching
- document tests in CHANGELOG

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_686a584fb958832ca7d7ff40f8bd0dbd