### PR TITLE
Add configurable field colors and header labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 - Added tests for TagFilterDialog, editor provider, element factory, and more lexer cases
 - Fixed TagFilterDialog tests to use built-in dictionaries by clearing custom paths
 
+### Added
+
+- Custom colours for field types in the table and tree views
+- Configurable header fields for message labels in table and tree views
+
 ### Fixed
 
 - Multi-line FpML fields no longer split messages when parsing

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ fields for different messages will be shown in the same row, making comparison e
 - **Message Hiding** in the transposed view for large message files
 - **Enumerated Values** suggested as items in the table view
 - **Override Dictionaries** with bespoke ones. Standard Quickfix dictionaries are used.
+- **Custom Field Colours** based on field type in table and tree views
+- **Configurable Header Labels** choose which fields appear in message labels
 - **Side-by-side diff viewer** for comparing two messages
 - **Language injection** for FIX messages embedded in code strings
 - **FpML Detection** for XML embedded in tags 351 and 213

--- a/src/main/java/com/rannett/fixplugin/settings/FixViewerSettingsConfigurable.java
+++ b/src/main/java/com/rannett/fixplugin/settings/FixViewerSettingsConfigurable.java
@@ -26,6 +26,9 @@ public class FixViewerSettingsConfigurable implements Configurable {
     private JPanel mainPanel;
     private JBTable versionTable;
     private DefaultTableModel tableModel;
+    private JBTable colorTable;
+    private DefaultTableModel colorModel;
+    private JTextField headerFieldsField;
     private final FixViewerSettingsState settingsState;
     private final Project project;
 
@@ -48,12 +51,16 @@ public class FixViewerSettingsConfigurable implements Configurable {
         tableModel = new DefaultTableModel(columnNames, 0);
         versionTable = new JBTable(tableModel);
 
+        String[] colorCols = {"Field Type", "Color (#RRGGBB)"};
+        colorModel = new DefaultTableModel(colorCols, 0);
+        colorTable = new JBTable(colorModel);
+
         // Setup file chooser descriptor
         FileChooserDescriptor fileDescriptor = FileChooserDescriptorFactory.createSingleFileDescriptor()
                 .withTitle("Select Custom Dictionary")
                 .withDescription("Choose an XML or JSON dictionary file.");
 
-        // Decorate the table with add/remove/edit
+        // Decorate the version table with add/remove/edit
         ToolbarDecorator decorator = ToolbarDecorator.createDecorator(versionTable)
                 .setAddAction(button -> tableModel.addRow(new Object[]{"", ""}))
                 .setRemoveAction(button -> {
@@ -92,21 +99,40 @@ public class FixViewerSettingsConfigurable implements Configurable {
                     }
                 });
 
+        ToolbarDecorator colorDecorator = ToolbarDecorator.createDecorator(colorTable)
+                .setAddAction(button -> colorModel.addRow(new Object[]{"", "#000000"}))
+                .setRemoveAction(button -> {
+                    int row = colorTable.getSelectedRow();
+                    if (row != -1) {
+                        colorModel.removeRow(row);
+                    }
+                });
+
+        headerFieldsField = new JTextField();
+
         mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.Y_AXIS));
         mainPanel.add(new JLabel("Custom Dictionary Mappings (FIX Version → Path):"));
         mainPanel.add(decorator.createPanel());
+        mainPanel.add(new JLabel("Field Type Colours:"));
+        mainPanel.add(colorDecorator.createPanel());
+        mainPanel.add(new JLabel("Header Fields (comma separated tags):"));
+        mainPanel.add(headerFieldsField);
 
         return mainPanel;
     }
 
     @Override
     public boolean isModified() {
-        return !settingsState.getCustomDictionaryPaths().equals(tableToMap());
+        return !settingsState.getCustomDictionaryPaths().equals(tableToMap()) ||
+                !settingsState.getFieldTypeColors().equals(colorTableToMap()) ||
+                !headerFieldsField.getText().trim().equals(settingsState.getHeaderLabelFields());
     }
 
     @Override
     public void apply() {
         settingsState.setCustomDictionaryPaths(tableToMap());
+        settingsState.setFieldTypeColors(colorTableToMap());
+        settingsState.setHeaderLabelFields(headerFieldsField.getText().trim());
     }
 
     @Override
@@ -115,6 +141,11 @@ public class FixViewerSettingsConfigurable implements Configurable {
         for (Map.Entry<String, String> entry : settingsState.getCustomDictionaryPaths().entrySet()) {
             tableModel.addRow(new Object[]{entry.getKey(), entry.getValue()});
         }
+        colorModel.setRowCount(0);
+        for (Map.Entry<String, String> entry : settingsState.getFieldTypeColors().entrySet()) {
+            colorModel.addRow(new Object[]{entry.getKey(), entry.getValue()});
+        }
+        headerFieldsField.setText(settingsState.getHeaderLabelFields());
     }
 
     @Override
@@ -129,6 +160,18 @@ public class FixViewerSettingsConfigurable implements Configurable {
             String path = (String) tableModel.getValueAt(i, 1);
             if (version != null && !version.trim().isEmpty() && path != null && !path.trim().isEmpty()) {
                 map.put(version.trim(), path.trim());
+            }
+        }
+        return map;
+    }
+
+    private Map<String, String> colorTableToMap() {
+        Map<String, String> map = new HashMap<>();
+        for (int i = 0; i < colorModel.getRowCount(); i++) {
+            String type = (String) colorModel.getValueAt(i, 0);
+            String color = (String) colorModel.getValueAt(i, 1);
+            if (type != null && !type.trim().isEmpty() && color != null && !color.trim().isEmpty()) {
+                map.put(type.trim(), color.trim());
             }
         }
         return map;

--- a/src/main/java/com/rannett/fixplugin/settings/FixViewerSettingsState.java
+++ b/src/main/java/com/rannett/fixplugin/settings/FixViewerSettingsState.java
@@ -20,6 +20,8 @@ import java.util.Map;
 public final class FixViewerSettingsState implements PersistentStateComponent<FixViewerSettingsState> {
 
     private Map<String, String> customDictionaryPaths = new HashMap<>();
+    private Map<String, String> fieldTypeColors = new HashMap<>();
+    private String headerLabelFields = "35,49,56,34,52";
 
     public static FixViewerSettingsState getInstance(Project project) {
         return project.getService(FixViewerSettingsState.class);
@@ -31,6 +33,78 @@ public final class FixViewerSettingsState implements PersistentStateComponent<Fi
 
     public void setCustomDictionaryPaths(Map<String, String> customDictionaryPaths) {
         this.customDictionaryPaths = customDictionaryPaths;
+    }
+
+    /**
+     * Return map of field type to color hex string.
+     */
+    public Map<String, String> getFieldTypeColors() {
+        return fieldTypeColors;
+    }
+
+    /**
+     * Set map of field type to color hex string.
+     *
+     * @param fieldTypeColors map of type names to hex colour values
+     */
+    public void setFieldTypeColors(Map<String, String> fieldTypeColors) {
+        this.fieldTypeColors = fieldTypeColors;
+    }
+
+    /**
+     * Get comma separated header field list used for message labels.
+     */
+    public String getHeaderLabelFields() {
+        return headerLabelFields;
+    }
+
+    /**
+     * Set comma separated header field list used for message labels.
+     */
+    public void setHeaderLabelFields(String headerLabelFields) {
+        this.headerLabelFields = headerLabelFields;
+    }
+
+    /**
+     * Parse the header label field configuration into a list of integers.
+     *
+     * @return ordered list of tag numbers to include in message labels
+     */
+    public java.util.List<Integer> getHeaderFieldList() {
+        java.util.List<Integer> result = new java.util.ArrayList<>();
+        for (String part : headerLabelFields.split(",")) {
+            String trimmed = part.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            try {
+                result.add(Integer.parseInt(trimmed));
+            } catch (NumberFormatException ignore) {
+                // Ignore invalid numbers
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Retrieve a color object for the given field type if configured.
+     *
+     * @param fieldType type name from the dictionary
+     * @return configured {@link java.awt.Color} or {@code null}
+     */
+    public java.awt.Color getColorForFieldType(String fieldType) {
+        if (fieldType == null) {
+            return null;
+        }
+        String hex = fieldTypeColors.get(fieldType);
+        if (hex == null || hex.isEmpty()) {
+            return null;
+        }
+        try {
+            return java.awt.Color.decode(hex);
+        } catch (NumberFormatException ignore) {
+            return null;
+        }
     }
 
     public String getCustomDictionaryPath(String fixVersion) {
@@ -45,5 +119,7 @@ public final class FixViewerSettingsState implements PersistentStateComponent<Fi
     @Override
     public void loadState(@NotNull FixViewerSettingsState state) {
         this.customDictionaryPaths = state.customDictionaryPaths;
+        this.fieldTypeColors = state.fieldTypeColors;
+        this.headerLabelFields = state.headerLabelFields;
     }
 }

--- a/src/main/java/com/rannett/fixplugin/ui/FixTransposedTablePanel.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixTransposedTablePanel.java
@@ -10,6 +10,7 @@ import com.intellij.ui.table.JBTable;
 import com.rannett.fixplugin.FixFileType;
 import com.rannett.fixplugin.dictionary.FixDictionaryCache;
 import com.rannett.fixplugin.dictionary.FixTagDictionary;
+import com.rannett.fixplugin.settings.FixViewerSettingsState;
 
 import javax.swing.DefaultCellEditor;
 import javax.swing.Icon;
@@ -71,8 +72,16 @@ public class FixTransposedTablePanel extends JPanel {
                 if (column >= 2) {
                     String tag = model.getTagAtRow(row);
                     String valStr = String.valueOf(value);
-                    FixTagDictionary dictionary = project.getService(FixDictionaryCache.class).getDictionary(model.getFixVersion());
-                    String desc = dictionary.getValueName(tag, valStr);
+                    FixTagDictionary dictionary = project != null ?
+                            project.getService(FixDictionaryCache.class).getDictionary(model.getFixVersion()) : null;
+                    String desc = dictionary != null ? dictionary.getValueName(tag, valStr) : null;
+                    String type = dictionary != null ? dictionary.getFieldType(tag) : null;
+                    java.awt.Color custom = project != null ? FixViewerSettingsState.getInstance(project).getColorForFieldType(type) : null;
+                    if (!isSelected && custom != null) {
+                        setForeground(custom);
+                    } else {
+                        setForeground(javax.swing.UIManager.getColor("Table.foreground"));
+                    }
                     if (desc != null && !desc.isEmpty()) {
                         displayValue = valStr + " (" + desc + ")";
                     }

--- a/src/test/java/com/rannett/fixplugin/util/FixMessageParserTest.java
+++ b/src/test/java/com/rannett/fixplugin/util/FixMessageParserTest.java
@@ -31,10 +31,11 @@ public class FixMessageParserTest {
         String msg = "8=FIX.4.2|9=65|35=A|49=S|56=T|34=2|52=20200101-00:00:00.000|10=000|";
         DataDictionary dd = FixMessageParser.loadDataDictionary("FIX.4.2", null);
         Message m = FixMessageParser.parse(msg, dd);
-        String label = FixMessageParser.buildMessageLabel(m, dd);
+        String label = FixMessageParser.buildMessageLabel(m, dd, java.util.List.of(35, 49, 56, 34, 52));
         assertTrue(label.contains("Logon"));
-        assertTrue(label.contains("S->T"));
-        assertTrue(label.contains("Seq 2"));
+        assertTrue(label.contains("SenderCompID=S"));
+        assertTrue(label.contains("TargetCompID=T"));
+        assertTrue(label.contains("MsgSeqNum=2"));
         assertTrue(label.contains("20200101-00:00:00.000"));
     }
 


### PR DESCRIPTION
## Summary
- allow custom field type colors and header label fields in settings
- color table and tree views using configured colors
- build message labels from configurable header fields
- adjust table model for new settings
- document new features in README and CHANGELOG
- update tests

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_686e1b66e32c832cbe49b0dd0956817a