### PR TITLE
Add FIX field lookup tool window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added tests for dictionary caching and additional lexer scenarios
 - Added tests for TagFilterDialog, editor provider, element factory, and more lexer cases
 - Fixed TagFilterDialog tests to use built-in dictionaries by clearing custom paths
+- Added FIX Field Lookup tool window for searching tag information
 
 ### Fixed
 

--- a/src/main/java/com/rannett/fixplugin/dictionary/FieldSection.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/FieldSection.java
@@ -1,0 +1,14 @@
+package com.rannett.fixplugin.dictionary;
+
+/**
+ * Enumeration of the sections within a FIX message where a field may appear.
+ */
+public enum FieldSection {
+    /** Field appears in the message header. */
+    HEADER,
+    /** Field appears in the message body. */
+    BODY,
+    /** Field appears in the message trailer. */
+    TRAILER
+}
+

--- a/src/main/java/com/rannett/fixplugin/ui/FixFieldLookupAction.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixFieldLookupAction.java
@@ -1,0 +1,33 @@
+package com.rannett.fixplugin.ui;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowManager;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Action to display the FIX Field Lookup tool window.
+ */
+public class FixFieldLookupAction extends AnAction implements DumbAware {
+
+    /**
+     * Opens or activates the tool window.
+     *
+     * @param e action event
+     */
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        Project project = e.getProject();
+        if (project == null) {
+            return;
+        }
+        ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow("Fix Field Lookup");
+        if (toolWindow != null) {
+            toolWindow.show();
+        }
+    }
+}
+

--- a/src/main/java/com/rannett/fixplugin/ui/FixFieldLookupPanel.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixFieldLookupPanel.java
@@ -1,0 +1,123 @@
+package com.rannett.fixplugin.ui;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.components.JBList;
+import com.intellij.ui.components.JBScrollPane;
+import com.intellij.ui.components.JBTextField;
+import com.intellij.openapi.util.text.StringUtil;
+import com.rannett.fixplugin.dictionary.FieldSection;
+import com.rannett.fixplugin.dictionary.FixDictionaryCache;
+import com.rannett.fixplugin.dictionary.FixTagDictionary;
+
+import javax.swing.DefaultListModel;
+import javax.swing.JPanel;
+import javax.swing.JTextArea;
+import javax.swing.ListSelectionModel;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import java.awt.BorderLayout;
+import java.util.Map;
+
+/**
+ * Panel providing search and display of FIX field information.
+ */
+public class FixFieldLookupPanel extends JPanel {
+
+    private final JBTextField searchField = new JBTextField();
+    private final JBList<String> resultList = new JBList<>(new DefaultListModel<>());
+    private final JTextArea detailsArea = new JTextArea();
+    private final FixTagDictionary dictionary;
+
+    /**
+     * Creates a panel for looking up FIX fields.
+     *
+     * @param project current project context
+     */
+    public FixFieldLookupPanel(Project project) {
+        super(new BorderLayout());
+        this.dictionary = project.getService(FixDictionaryCache.class).getDictionary("FIX.4.4");
+        resultList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        detailsArea.setEditable(false);
+        add(searchField, BorderLayout.NORTH);
+        add(new JBScrollPane(resultList), BorderLayout.WEST);
+        add(new JBScrollPane(detailsArea), BorderLayout.CENTER);
+
+        searchField.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                updateResults();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                updateResults();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                updateResults();
+            }
+        });
+
+        resultList.addListSelectionListener(e -> showDetails());
+    }
+
+    private void updateResults() {
+        String term = searchField.getText().trim();
+        DefaultListModel<String> model = (DefaultListModel<String>) resultList.getModel();
+        model.clear();
+        if (term.isEmpty()) {
+            return;
+        }
+        dictionary.getTagNameMap().entrySet().stream()
+                .filter(entry -> matches(entry.getKey(), entry.getValue(), term))
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> model.addElement(entry.getKey() + " (" + entry.getValue() + ")"));
+    }
+
+    private boolean matches(String tag, String name, String term) {
+        if (StringUtil.containsIgnoreCase(tag, term) || StringUtil.containsIgnoreCase(name, term)) {
+            return true;
+        }
+        Map<String, String> values = dictionary.getValueMap(tag);
+        return values != null && values.entrySet().stream()
+                .anyMatch(e -> StringUtil.containsIgnoreCase(e.getKey(), term)
+                        || StringUtil.containsIgnoreCase(e.getValue(), term));
+    }
+
+    private void showDetails() {
+        String selected = resultList.getSelectedValue();
+        if (selected == null) {
+            detailsArea.setText("");
+            return;
+        }
+        String tag = selected.split(" ", 2)[0];
+        StringBuilder sb = new StringBuilder();
+        sb.append("Tag: ").append(tag).append("\n");
+        String name = dictionary.getTagName(tag);
+        if (name != null) {
+            sb.append("Name: ").append(name).append("\n");
+        }
+        String type = dictionary.getFieldType(tag);
+        if (type != null) {
+            sb.append("Type: ").append(type).append("\n");
+        }
+        FieldSection section = dictionary.getFieldSection(tag);
+        if (section != null) {
+            sb.append("Section: ").append(section.name()).append("\n");
+        }
+        Map<String, String> values = dictionary.getValueMap(tag);
+        if (values != null && !values.isEmpty()) {
+            sb.append("Values:\n");
+            values.entrySet().stream()
+                    .sorted(Map.Entry.comparingByKey())
+                    .forEach(e -> sb.append("  ")
+                            .append(e.getKey())
+                            .append(" = ")
+                            .append(e.getValue())
+                            .append("\n"));
+        }
+        detailsArea.setText(sb.toString());
+    }
+}
+

--- a/src/main/java/com/rannett/fixplugin/ui/FixFieldLookupToolWindowFactory.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixFieldLookupToolWindowFactory.java
@@ -1,0 +1,29 @@
+package com.rannett.fixplugin.ui;
+
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowFactory;
+import com.intellij.ui.content.Content;
+import com.intellij.ui.content.ContentFactory;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Factory for the FIX Field Lookup tool window.
+ */
+public class FixFieldLookupToolWindowFactory implements ToolWindowFactory, DumbAware {
+
+    /**
+     * Creates the tool window content.
+     *
+     * @param project    current project
+     * @param toolWindow tool window instance
+     */
+    @Override
+    public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
+        FixFieldLookupPanel panel = new FixFieldLookupPanel(project);
+        Content content = ContentFactory.getInstance().createContent(panel, "", false);
+        toolWindow.getContentManager().addContent(content);
+    }
+}
+

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -45,6 +45,12 @@
         <multiHostInjector
                 implementation="com.rannett.fixplugin.injection.FixStringLanguageInjector"/>
 
+        <toolWindow
+                id="Fix Field Lookup"
+                anchor="right"
+                factoryClass="com.rannett.fixplugin.ui.FixFieldLookupToolWindowFactory"
+                icon="/icons/fix-16x16.png"/>
+
     </extensions>
     <extensions defaultExtensionNs="com.intellij">
         <projectConfigurable
@@ -53,4 +59,13 @@
                 instance="com.rannett.fixplugin.settings.FixViewerSettingsConfigurable"
                 parentId="tools"/>
     </extensions>
+
+    <actions>
+        <action id="FixFieldLookupAction"
+                class="com.rannett.fixplugin.ui.FixFieldLookupAction"
+                text="FIX Field Lookup"
+                description="Lookup FIX field information">
+            <add-to-group group-id="ToolsMenu" anchor="last"/>
+        </action>
+    </actions>
 </idea-plugin>

--- a/src/test/java/com/rannett/fixplugin/dictionary/FixTagDictionaryTest.java
+++ b/src/test/java/com/rannett/fixplugin/dictionary/FixTagDictionaryTest.java
@@ -3,6 +3,7 @@ package com.rannett.fixplugin.dictionary;
 import org.junit.Assert;
 import org.junit.Test;
 
+
 import java.io.File;
 import java.io.FileWriter;
 import java.util.Map;
@@ -108,6 +109,14 @@ public class FixTagDictionaryTest {
         assertEquals("MsgType", dictionary.getTagName("35"));
         // verify field type lookup from built-in dictionaries
         assertEquals("STRING", dictionary.getFieldType("35"));
+    }
+
+    @Test
+    public void testFieldSectionsFromBuiltIn() {
+        FixTagDictionary dictionary = FixTagDictionary.fromBuiltInVersion("FIX.4.4");
+        assertEquals(FieldSection.HEADER, dictionary.getFieldSection("8"));
+        assertEquals(FieldSection.TRAILER, dictionary.getFieldSection("10"));
+        assertEquals(FieldSection.BODY, dictionary.getFieldSection("55"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add dedicated FIX Field Lookup tool window and Tools menu action
- parse dictionary header and trailer sections to classify tags
- expose tag section lookup and tests

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_689cbee77214832c9f8b8c6105c725e4