### PR TITLE
Add field descriptions from FIX phrases to lookup tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added tests for TagFilterDialog, editor provider, element factory, and more lexer cases
 - Fixed TagFilterDialog tests to use built-in dictionaries by clearing custom paths
 - Added FIX Field Lookup tool window for searching tag information
+- Display field descriptions in Field Lookup using FIX.5.0SP2 phrases
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed TagFilterDialog tests to use built-in dictionaries by clearing custom paths
 - Added FIX Field Lookup tool window for searching tag information
 - Display field descriptions in Field Lookup using FIX.5.0SP2 phrases
+- Wrapped field descriptions in Field Lookup to avoid horizontal scrolling
 
 ### Fixed
 

--- a/src/main/java/com/rannett/fixplugin/ui/FixFieldLookupPanel.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixFieldLookupPanel.java
@@ -106,6 +106,10 @@ public class FixFieldLookupPanel extends JPanel {
         if (section != null) {
             sb.append("Section: ").append(section.name()).append("\n");
         }
+        String description = dictionary.getFieldDescription(tag);
+        if (description != null) {
+            sb.append("Description: ").append(description).append("\n");
+        }
         Map<String, String> values = dictionary.getValueMap(tag);
         if (values != null && !values.isEmpty()) {
             sb.append("Values:\n");

--- a/src/main/java/com/rannett/fixplugin/ui/FixFieldLookupPanel.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixFieldLookupPanel.java
@@ -38,6 +38,8 @@ public class FixFieldLookupPanel extends JPanel {
         this.dictionary = project.getService(FixDictionaryCache.class).getDictionary("FIX.4.4");
         resultList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         detailsArea.setEditable(false);
+        detailsArea.setLineWrap(true);
+        detailsArea.setWrapStyleWord(true);
         add(searchField, BorderLayout.NORTH);
         add(new JBScrollPane(resultList), BorderLayout.WEST);
         add(new JBScrollPane(detailsArea), BorderLayout.CENTER);

--- a/src/test/java/com/rannett/fixplugin/dictionary/FixTagDictionaryTest.java
+++ b/src/test/java/com/rannett/fixplugin/dictionary/FixTagDictionaryTest.java
@@ -120,6 +120,14 @@ public class FixTagDictionaryTest {
     }
 
     @Test
+    public void testFieldDescriptionFromPhrases() {
+        FixTagDictionary dictionary = FixTagDictionary.fromBuiltInVersion("FIX.4.4");
+        assertEquals(
+                "Account mnemonic as agreed between buy and sell sides, e.g. broker and institution or investor/intermediary and fund manager.",
+                dictionary.getFieldDescription("1"));
+    }
+
+    @Test
     public void testFromBuiltInVersion_missingFile() {
         FixTagDictionary dictionary = FixTagDictionary.fromBuiltInVersion("nonexistent-version");
         assertNull(dictionary.getTagName("35"));

--- a/src/test/java/com/rannett/fixplugin/ui/FixFieldLookupPanelTest.java
+++ b/src/test/java/com/rannett/fixplugin/ui/FixFieldLookupPanelTest.java
@@ -1,0 +1,31 @@
+package com.rannett.fixplugin.ui;
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+import javax.swing.JTextArea;
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link FixFieldLookupPanel}.
+ */
+public class FixFieldLookupPanelTest extends BasePlatformTestCase {
+
+    /**
+     * Ensures that the details text area wraps long lines so horizontal scrolling is unnecessary.
+     */
+    public void testDescriptionWraps() {
+        JTextArea area;
+        try {
+            FixFieldLookupPanel panel = new FixFieldLookupPanel(getProject());
+            Field field = FixFieldLookupPanel.class.getDeclaredField("detailsArea");
+            field.setAccessible(true);
+            area = (JTextArea) field.get(panel);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        assertTrue(area.getLineWrap());
+        assertTrue(area.getWrapStyleWord());
+    }
+}


### PR DESCRIPTION
## Summary
- load field descriptions from `FIX.5.0SP2_en_phrases.xml`
- show field descriptions in the FIX Field Lookup tool
- test loading of descriptions and update changelog

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68a9b60b628c832c9e9542744ee5377f