### PR TITLE
Add communications timeline view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Added FIX Field Lookup tool window for searching tag information
 - Display field descriptions in Field Lookup using FIX.5.0SP2 phrases
 - Wrapped field descriptions in Field Lookup to avoid horizontal scrolling
-- Added communications timeline view for inspecting message sequences
+- Added Message Flow view for inspecting message sequences with direction indicators
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,31 +3,6 @@
 # fix-plugin2 Changelog
 
 ## [Unreleased]
-- Added language injection for FIX messages embedded in code strings
-- Added tests for language injection
-- Added tests for dictionary caching and additional lexer scenarios
-- Added tests for TagFilterDialog, editor provider, element factory, and more lexer cases
-- Fixed TagFilterDialog tests to use built-in dictionaries by clearing custom paths
-- Added FIX Field Lookup tool window for searching tag information
-- Display field descriptions in Field Lookup using FIX.5.0SP2 phrases
-- Wrapped field descriptions in Field Lookup to avoid horizontal scrolling
-- Added Message Flow view for inspecting message sequences with direction indicators
-- Message Flow displays FIX message names alongside type codes
-- Message Flow columns reordered to Time, Dir, MsgType, Summary with Time column widened
-
-### Fixed
-
-- Multi-line FpML fields no longer split messages when parsing
-- Invalid character warnings are no longer reported for FpML text in XmlData or EncodedSecurityDesc fields.
-- Invalid character warnings are no longer reported for FpML text in XmlData or
-  EncodedSecurityDesc fields.
-- Transposed table no longer shrinks columns when many messages are displayed; a horizontal scrollbar appears instead.
-
-### Added
-
-- Support for extended precision UTCTimestamps with optional trailing `Z`.
-- Detection and parsing of FpML in XMLData and EncodedSecurityDesc fields.
-- Fixed lexer handling of whitespace inside embedded FpML and added lexer tests.
 
 ## [0.0.1]
 
@@ -118,6 +93,10 @@
 - Side-by-side comparison of FIX messages using IntelliJ diff viewer
 - Display enum descriptions alongside field names in the tree view
 - Filtering in the transposed table view and ability to reset filtering and ordering.
+- Multi-line FpML fields no longer split messages when parsing
+- Invalid character warnings are no longer reported for FpML text in XmlData or
+  EncodedSecurityDesc fields.
+- Transposed table no longer shrinks columns when many messages are displayed; a horizontal scrollbar appears instead.
 
 ## [0.0.14]
 
@@ -136,3 +115,13 @@
 - Added tests for dictionary caching and additional lexer scenarios
 - Added tests for TagFilterDialog, editor provider, element factory, and more lexer cases
 - Fixed TagFilterDialog tests to use built-in dictionaries by clearing custom paths
+- Display field descriptions in Field Lookup using FIX.5.0SP2 phrases
+- Wrapped field descriptions in Field Lookup to avoid horizontal scrolling
+
+## [0.0.15]
+
+### Added
+
+- Added Message Flow view for inspecting message sequences with direction indicators
+- Message Flow displays FIX message names alongside type codes
+- Message Flow columns reordered to Time, Dir, MsgType, Summary with Time column widened

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Wrapped field descriptions in Field Lookup to avoid horizontal scrolling
 - Added Message Flow view for inspecting message sequences with direction indicators
 - Message Flow displays FIX message names alongside type codes
+- Message Flow summary column expands to show message fields and Time/Dir columns use fixed widths
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Wrapped field descriptions in Field Lookup to avoid horizontal scrolling
 - Added Message Flow view for inspecting message sequences with direction indicators
 - Message Flow displays FIX message names alongside type codes
-- Message Flow summary column expands to show message fields and Time/Dir columns use fixed widths
+- Message Flow columns reordered to Time, Dir, MsgType, Summary with Time column widened
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Display field descriptions in Field Lookup using FIX.5.0SP2 phrases
 - Wrapped field descriptions in Field Lookup to avoid horizontal scrolling
 - Added Message Flow view for inspecting message sequences with direction indicators
+- Message Flow displays FIX message names alongside type codes
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added FIX Field Lookup tool window for searching tag information
 - Display field descriptions in Field Lookup using FIX.5.0SP2 phrases
 - Wrapped field descriptions in Field Lookup to avoid horizontal scrolling
+- Added communications timeline view for inspecting message sequences
 
 ### Fixed
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 pluginGroup=com.rannett.fix-viewer
 pluginName=Financial Information eXchange Message Viewer
 # SemVer format -> https://semver.org
-pluginVersion=0.0.14
+pluginVersion=0.0.15
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=242
 pluginUntilBuild=252.*

--- a/src/main/java/com/rannett/fixplugin/ui/FixCommTimelinePanel.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixCommTimelinePanel.java
@@ -1,0 +1,155 @@
+package com.rannett.fixplugin.ui;
+
+import com.intellij.ui.components.JBScrollPane;
+import com.intellij.ui.table.JBTable;
+import com.rannett.fixplugin.util.FixMessageParser;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.BorderFactory;
+import javax.swing.JCheckBox;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.table.DefaultTableModel;
+import java.awt.BorderLayout;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+
+import quickfix.DataDictionary;
+import quickfix.Message;
+
+/**
+ * Panel that renders a simple timeline view of FIX messages.
+ */
+public class FixCommTimelinePanel extends JPanel {
+    private final DefaultTableModel model;
+    private final JTable table;
+    private final JCheckBox hideHeartbeat;
+    private final List<RowData> allRows = new ArrayList<>();
+    private final List<RowData> displayedRows = new ArrayList<>();
+    private Consumer<Integer> onMessageSelected;
+
+    public FixCommTimelinePanel(@NotNull List<String> messages) {
+        super(new BorderLayout());
+        model = new DefaultTableModel(new Object[]{"Time", "Dir", "MsgType", "Summary"}, 0) {
+            @Override
+            public boolean isCellEditable(int row, int column) {
+                return false;
+            }
+        };
+        table = new JBTable(model);
+        hideHeartbeat = new JCheckBox("Hide heartbeats");
+        hideHeartbeat.addActionListener(e -> applyFilter());
+        JScrollPane scroll = new JBScrollPane(table);
+        scroll.setBorder(BorderFactory.createEmptyBorder());
+        add(hideHeartbeat, BorderLayout.NORTH);
+        add(scroll, BorderLayout.CENTER);
+
+        table.getSelectionModel().addListSelectionListener(e -> notifySelection());
+        loadMessages(messages);
+    }
+
+    /**
+     * Update the timeline with new messages.
+     */
+    public void updateMessages(@NotNull List<String> messages) {
+        loadMessages(messages);
+    }
+
+    /**
+     * Configure a callback when a message row is selected.
+     *
+     * @param callback consumer receiving the 1-based message index
+     */
+    public void setOnMessageSelected(Consumer<Integer> callback) {
+        this.onMessageSelected = callback;
+    }
+
+    /**
+     * Set whether heartbeat messages should be hidden.
+     */
+    public void setHideHeartbeats(boolean hide) {
+        hideHeartbeat.setSelected(hide);
+        applyFilter();
+    }
+
+    /**
+     * Return the number of visible rows.
+     */
+    public int getVisibleRowCount() {
+        return model.getRowCount();
+    }
+
+    private void loadMessages(List<String> messages) {
+        allRows.clear();
+        IntStream.range(0, messages.size()).forEach(i -> {
+            RowData row = parseRow(messages.get(i), i + 1);
+            allRows.add(row);
+        });
+        applyFilter();
+    }
+
+    private void applyFilter() {
+        model.setRowCount(0);
+        displayedRows.clear();
+        allRows.stream()
+                .filter(r -> !hideHeartbeat.isSelected() || !"0".equals(r.msgType))
+                .forEach(r -> {
+                    displayedRows.add(r);
+                    model.addRow(new Object[]{r.time, r.direction, r.msgType, r.summary});
+                });
+    }
+
+    private void notifySelection() {
+        int row = table.getSelectedRow();
+        if (row >= 0 && row < displayedRows.size() && onMessageSelected != null) {
+            onMessageSelected.accept(displayedRows.get(row).index);
+        }
+    }
+
+    private RowData parseRow(String msg, int index) {
+        String begin = extractBeginString(msg);
+        try {
+            DataDictionary dd = FixMessageParser.loadDataDictionary(begin, null);
+            Message parsed = FixMessageParser.parse(msg, dd);
+            String time = parsed.getHeader().isSetField(52) ? parsed.getHeader().getString(52) : "";
+            String type = parsed.getHeader().isSetField(35) ? parsed.getHeader().getString(35) : "";
+            String summary = FixMessageParser.buildMessageLabel(parsed, dd);
+            return new RowData(index, time, "→", type, summary);
+        } catch (Exception e) {
+            return new RowData(index, "", "→", "", msg);
+        }
+    }
+
+    private static String extractBeginString(String msg) {
+        int start = msg.indexOf("8=");
+        if (start >= 0) {
+            int pipe = msg.indexOf('|', start);
+            int soh = msg.indexOf('\u0001', start);
+            int end = pipe >= 0 && (soh < 0 || pipe < soh) ? pipe : soh;
+            if (end > start) {
+                return msg.substring(start + 2, end);
+            }
+        }
+        return "FIX.4.4";
+    }
+
+    private static final class RowData {
+        final int index;
+        final String time;
+        final String direction;
+        final String msgType;
+        final String summary;
+
+        RowData(int index, String time, String direction, String msgType, String summary) {
+            this.index = index;
+            this.time = time;
+            this.direction = direction;
+            this.msgType = msgType;
+            this.summary = summary;
+        }
+    }
+}
+

--- a/src/main/java/com/rannett/fixplugin/ui/FixCommTimelinePanel.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixCommTimelinePanel.java
@@ -53,7 +53,6 @@ public class FixCommTimelinePanel extends JPanel {
         super(new BorderLayout());
 
         ColumnInfo[] columns = new ColumnInfo[]{
-                new TreeColumnInfo("Summary"),
                 new ColumnInfo<DefaultMutableTreeNode, String>("Time") {
                     @Override
                     public String valueOf(DefaultMutableTreeNode node) {
@@ -80,7 +79,8 @@ public class FixCommTimelinePanel extends JPanel {
                         }
                         return "";
                     }
-                }
+                },
+                new TreeColumnInfo("Summary")
         };
 
         model = new ListTreeTableModelOnColumns(root, columns);
@@ -317,17 +317,25 @@ public class FixCommTimelinePanel extends JPanel {
     }
 
     private void fixColumnWidths() {
-        TableColumn timeColumn = table.getColumnModel().getColumn(1);
-        timeColumn.setMinWidth(120);
-        timeColumn.setMaxWidth(120);
-        timeColumn.setPreferredWidth(120);
+        TableColumn timeColumn = table.getColumnModel().getColumn(0);
+        timeColumn.setMinWidth(150);
+        timeColumn.setMaxWidth(150);
+        timeColumn.setPreferredWidth(150);
         timeColumn.setResizable(false);
 
-        TableColumn dirColumn = table.getColumnModel().getColumn(2);
+        TableColumn dirColumn = table.getColumnModel().getColumn(1);
         dirColumn.setMinWidth(40);
         dirColumn.setMaxWidth(40);
         dirColumn.setPreferredWidth(40);
         dirColumn.setResizable(false);
+    }
+
+    String getColumnName(int index) {
+        return table.getColumnModel().getColumn(index).getHeaderValue().toString();
+    }
+
+    int getColumnPreferredWidth(int index) {
+        return table.getColumnModel().getColumn(index).getPreferredWidth();
     }
 
     private static final class MessageNode extends DefaultMutableTreeNode {

--- a/src/main/java/com/rannett/fixplugin/ui/FixDualViewEditor.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixDualViewEditor.java
@@ -29,6 +29,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.IntStream;
+
 import com.rannett.fixplugin.util.FixMessageParser;
 
 public class FixDualViewEditor extends UserDataHolderBase implements FileEditor {
@@ -37,6 +39,7 @@ public class FixDualViewEditor extends UserDataHolderBase implements FileEditor 
     private final JTabbedPane tabbedPane;
     private final FixTransposedTablePanel tablePanel;
     private final FixMessageTreePanel treePanel;
+    private final FixCommTimelinePanel commPanel;
     private final Document document;
     private final VirtualFile file;
     private Integer pendingCaretOffset = null;
@@ -76,6 +79,16 @@ public class FixDualViewEditor extends UserDataHolderBase implements FileEditor 
 
         treePanel = new FixMessageTreePanel(messages, project);
         tabbedPane.addTab("Tree View", treePanel);
+
+        commPanel = new FixCommTimelinePanel(messages);
+        commPanel.setOnMessageSelected(idx -> {
+            int offset = findMessageOffset(idx);
+            if (offset >= 0) {
+                pendingCaretOffset = offset;
+                tablePanel.highlightTagCell("8", "Message " + idx);
+            }
+        });
+        tabbedPane.addTab("Comm", commPanel);
         mainPanel.add(tabbedPane, BorderLayout.CENTER);
 
         // Full rebuild and revalidation on document change
@@ -86,6 +99,7 @@ public class FixDualViewEditor extends UserDataHolderBase implements FileEditor 
                     List<String> updatedMessages = FixMessageParser.splitMessages(document.getText());
                     tablePanel.updateTable(updatedMessages);
                     treePanel.updateTree(updatedMessages);
+                    commPanel.updateMessages(updatedMessages);
                 });
             }
         });
@@ -166,6 +180,16 @@ public class FixDualViewEditor extends UserDataHolderBase implements FileEditor 
         return offset + tagIndex;
     }
 
+    private int findMessageOffset(int messageIndex) {
+        List<String> lines = FixMessageParser.splitMessages(document.getText());
+        if (messageIndex < 1 || messageIndex > lines.size()) {
+            return -1;
+        }
+        return IntStream.range(0, messageIndex - 1)
+                .map(i -> lines.get(i).length() + 1)
+                .sum();
+    }
+
     @Override
     public @NotNull JComponent getComponent() {
         return mainPanel;
@@ -174,9 +198,16 @@ public class FixDualViewEditor extends UserDataHolderBase implements FileEditor 
     @Override
     public @Nullable JComponent getPreferredFocusedComponent() {
         int index = tabbedPane.getSelectedIndex();
-        if (index == 0) return textEditor.getPreferredFocusedComponent();
-        if (index == 1) return tablePanel;
-        return treePanel;
+        if (index == 0) {
+            return textEditor.getPreferredFocusedComponent();
+        }
+        if (index == 1) {
+            return tablePanel;
+        }
+        if (index == 2) {
+            return treePanel;
+        }
+        return commPanel;
     }
 
     @Override

--- a/src/main/java/com/rannett/fixplugin/ui/FixDualViewEditor.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixDualViewEditor.java
@@ -88,7 +88,7 @@ public class FixDualViewEditor extends UserDataHolderBase implements FileEditor 
                 tablePanel.highlightTagCell("8", "Message " + idx);
             }
         });
-        tabbedPane.addTab("Comm", commPanel);
+        tabbedPane.addTab("Message Flow", commPanel);
         mainPanel.add(tabbedPane, BorderLayout.CENTER);
 
         // Full rebuild and revalidation on document change

--- a/src/test/java/com/rannett/fixplugin/ui/FixCommTimelinePanelTest.java
+++ b/src/test/java/com/rannett/fixplugin/ui/FixCommTimelinePanelTest.java
@@ -1,0 +1,24 @@
+package com.rannett.fixplugin.ui;
+
+import org.junit.Test;
+
+import javax.swing.SwingUtilities;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class FixCommTimelinePanelTest {
+    @Test
+    public void testHideHeartbeats() throws Exception {
+        List<String> messages = List.of(
+                "8=FIX.4.4|35=A|10=001|",
+                "8=FIX.4.4|35=0|10=002|"
+        );
+        SwingUtilities.invokeAndWait(() -> {
+            FixCommTimelinePanel panel = new FixCommTimelinePanel(messages);
+            assertEquals(2, panel.getVisibleRowCount());
+            panel.setHideHeartbeats(true);
+            assertEquals(1, panel.getVisibleRowCount());
+        });
+    }
+}

--- a/src/test/java/com/rannett/fixplugin/ui/FixCommTimelinePanelTest.java
+++ b/src/test/java/com/rannett/fixplugin/ui/FixCommTimelinePanelTest.java
@@ -38,4 +38,17 @@ public class FixCommTimelinePanelTest {
             assertEquals("←", panel.getDirectionAtRow(3));
         });
     }
+
+    @Test
+    public void testMsgTypeNames() throws Exception {
+        List<String> messages = List.of(
+                "8=FIX.4.4|35=A|10=001|",
+                "8=FIX.4.4|35=D|10=002|"
+        );
+        SwingUtilities.invokeAndWait(() -> {
+            FixCommTimelinePanel panel = new FixCommTimelinePanel(messages);
+            assertEquals("A (LOGON)", panel.getMsgTypeAtRow(0));
+            assertEquals("D (NEWORDERSINGLE)", panel.getMsgTypeAtRow(1));
+        });
+    }
 }

--- a/src/test/java/com/rannett/fixplugin/ui/FixCommTimelinePanelTest.java
+++ b/src/test/java/com/rannett/fixplugin/ui/FixCommTimelinePanelTest.java
@@ -21,4 +21,21 @@ public class FixCommTimelinePanelTest {
             assertEquals(1, panel.getVisibleRowCount());
         });
     }
+
+    @Test
+    public void testDirectionDetection() throws Exception {
+        List<String> messages = List.of(
+                "8=FIXT.1.1|9=65|35=A|34=1|49=BUY_SIDE|56=SELL_SIDE|52=20250829-09:00:00.000|98=0|108=30|141=Y|10=072|",
+                "8=FIXT.1.1|9=65|35=A|34=1|49=SELL_SIDE|56=BUY_SIDE|52=20250829-09:00:00.100|98=0|108=30|141=Y|10=082|",
+                "8=FIXT.1.1|9=49|35=0|34=2|49=BUY_SIDE|56=SELL_SIDE|52=20250829-09:00:30.000|10=239|",
+                "8=FIXT.1.1|9=49|35=0|34=2|49=SELL_SIDE|56=BUY_SIDE|52=20250829-09:00:30.100|10=249|"
+        );
+        SwingUtilities.invokeAndWait(() -> {
+            FixCommTimelinePanel panel = new FixCommTimelinePanel(messages);
+            assertEquals("→", panel.getDirectionAtRow(0));
+            assertEquals("←", panel.getDirectionAtRow(1));
+            assertEquals("→", panel.getDirectionAtRow(2));
+            assertEquals("←", panel.getDirectionAtRow(3));
+        });
+    }
 }

--- a/src/test/java/com/rannett/fixplugin/ui/FixCommTimelinePanelTest.java
+++ b/src/test/java/com/rannett/fixplugin/ui/FixCommTimelinePanelTest.java
@@ -51,4 +51,17 @@ public class FixCommTimelinePanelTest {
             assertEquals("D (NEWORDERSINGLE)", panel.getMsgTypeAtRow(1));
         });
     }
+
+    @Test
+    public void testColumnOrderAndWidth() throws Exception {
+        List<String> messages = List.of("8=FIX.4.4|35=A|10=001|");
+        SwingUtilities.invokeAndWait(() -> {
+            FixCommTimelinePanel panel = new FixCommTimelinePanel(messages);
+            assertEquals("Time", panel.getColumnName(0));
+            assertEquals("Dir", panel.getColumnName(1));
+            assertEquals("MsgType", panel.getColumnName(2));
+            assertEquals("Summary", panel.getColumnName(3));
+            assertEquals(150, panel.getColumnPreferredWidth(0));
+        });
+    }
 }


### PR DESCRIPTION
## Summary
- introduce Communications timeline panel with heartbeat filter and selection sync
- wire new Comm tab into dual view editor and update on document changes
- add basic unit test for heartbeat filtering

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b0c16c3064832ca9be893b98c0932d