### PR TITLE
Refresh FIX views after dictionary updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Display the active dictionary for each open FIX viewer, highlighting modified dictionary locations.
+
 ### Fixed
 
 - Refresh open FIX editors immediately after updating custom dictionary mappings so IDE restarts are no longer required.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - Refresh open FIX editors immediately after updating custom dictionary mappings so IDE restarts are no longer required.
 - Fix dictionary change event subscription so builds compile with the IntelliJ message bus APIs.
+- Replace the dictionary mapping edit dialog with an IntelliJ DialogWrapper implementation to avoid thread context errors
+  when updating dictionaries from the settings panel.
 
 ## [0.0.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Refresh open FIX editors immediately after updating custom dictionary mappings so IDE restarts are no longer required.
+
 ## [0.0.1]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - Refresh open FIX editors immediately after updating custom dictionary mappings so IDE restarts are no longer required.
+- Fix dictionary change event subscription so builds compile with the IntelliJ message bus APIs.
 
 ## [0.0.1]
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ fields for different messages will be shown in the same row, making comparison e
 - **Message Hiding** in the transposed view for large message files
 - **Enumerated Values** suggested as items in the table view
 - **Override Dictionaries** with bespoke ones. Standard Quickfix dictionaries are used.
+- **Dictionary Indicator** shows whether each FIX version uses the default or a modified dictionary directly in the viewers.
 - **Side-by-side diff viewer** for comparing two messages
 - **Language injection** for FIX messages embedded in code strings
 - **FpML Detection** for XML embedded in tags 351 and 213

--- a/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryCache.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryCache.java
@@ -23,6 +23,13 @@ public final class FixDictionaryCache {
         return cache.computeIfAbsent(version, v -> loadDictionary(project, v));
     }
 
+    /**
+     * Clears the cached dictionaries so that subsequent lookups reload from disk or bundled resources.
+     */
+    public void clear() {
+        cache.clear();
+    }
+
     private FixTagDictionary loadDictionary(Project project, String fixVersion) {
         FixViewerSettingsState settings = FixViewerSettingsState.getInstance(project);
 

--- a/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryChangeListener.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryChangeListener.java
@@ -1,0 +1,22 @@
+package com.rannett.fixplugin.dictionary;
+
+import com.intellij.util.messages.Topic;
+
+/**
+ * Listener notified when FIX dictionary mappings change for a project.
+ */
+public interface FixDictionaryChangeListener {
+
+    /**
+     * Topic used to broadcast dictionary change events to interested components.
+     */
+    Topic<FixDictionaryChangeListener> TOPIC = Topic.create(
+            "Fix Dictionary Changes",
+            FixDictionaryChangeListener.class
+    );
+
+    /**
+     * Invoked when the active FIX dictionary mappings for the project are updated.
+     */
+    void onDictionariesChanged();
+}

--- a/src/main/java/com/rannett/fixplugin/settings/DictionaryMappingEditDialog.java
+++ b/src/main/java/com/rannett/fixplugin/settings/DictionaryMappingEditDialog.java
@@ -1,0 +1,92 @@
+package com.rannett.fixplugin.settings;
+
+import com.intellij.openapi.fileChooser.FileChooserDescriptor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.openapi.ui.TextBrowseFolderListener;
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+
+/**
+ * Dialog used to edit a FIX version to dictionary path mapping.
+ */
+public class DictionaryMappingEditDialog extends DialogWrapper {
+
+    private final JTextField versionField;
+    private final TextFieldWithBrowseButton pathField;
+    private final JPanel contentPanel;
+
+    /**
+     * Creates a dialog for editing a FIX dictionary mapping.
+     *
+     * @param project         the current project hosting the dialog
+     * @param currentVersion  the version currently stored in the mapping row
+     * @param currentPath     the dictionary path currently stored in the mapping row
+     * @param descriptor      descriptor describing valid dictionary files
+     */
+    public DictionaryMappingEditDialog(@Nullable Project project,
+                                       @Nullable String currentVersion,
+                                       @Nullable String currentPath,
+                                       FileChooserDescriptor descriptor) {
+        super(project, true);
+        setTitle("Edit Mapping");
+        versionField = new JTextField(currentVersion != null ? currentVersion : "");
+        pathField = new TextFieldWithBrowseButton();
+        if (descriptor != null) {
+            pathField.addBrowseFolderListener(new TextBrowseFolderListener(descriptor, project));
+        }
+        pathField.setText(currentPath != null ? currentPath : "");
+        contentPanel = buildContentPanel();
+        init();
+    }
+
+    private JPanel buildContentPanel() {
+        JPanel panel = new JPanel(new GridBagLayout());
+        GridBagConstraints constraints = new GridBagConstraints();
+        constraints.insets = new Insets(4, 0, 4, 0);
+        constraints.fill = GridBagConstraints.HORIZONTAL;
+        constraints.weightx = 1.0;
+        constraints.gridx = 0;
+        constraints.gridy = 0;
+
+        panel.add(new JLabel("FIX Version:"), constraints);
+
+        constraints.gridy = 1;
+        panel.add(versionField, constraints);
+
+        constraints.gridy = 2;
+        panel.add(new JLabel("Custom Dictionary Path:"), constraints);
+
+        constraints.gridy = 3;
+        panel.add(pathField, constraints);
+
+        return panel;
+    }
+
+    @Override
+    protected @Nullable JComponent createCenterPanel() {
+        return contentPanel;
+    }
+
+    /**
+     * @return the FIX version entered by the user.
+     */
+    public String getVersion() {
+        return versionField.getText().trim();
+    }
+
+    /**
+     * @return the dictionary path selected by the user.
+     */
+    public String getDictionaryPath() {
+        return pathField.getText().trim();
+    }
+}

--- a/src/main/java/com/rannett/fixplugin/settings/FixViewerSettingsConfigurable.java
+++ b/src/main/java/com/rannett/fixplugin/settings/FixViewerSettingsConfigurable.java
@@ -5,8 +5,6 @@ import com.intellij.openapi.fileChooser.FileChooserDescriptor;
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.TextBrowseFolderListener;
-import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.ui.ToolbarDecorator;
 import com.intellij.ui.table.JBTable;
 import com.rannett.fixplugin.dictionary.FixDictionaryCache;
@@ -17,9 +15,7 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.BoxLayout;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
-import javax.swing.JOptionPane;
 import javax.swing.JPanel;
-import javax.swing.JTextField;
 import javax.swing.table.DefaultTableModel;
 import java.util.HashMap;
 import java.util.Map;
@@ -70,27 +66,15 @@ public class FixViewerSettingsConfigurable implements Configurable {
                     if (selectedRow != -1) {
                         String currentVersion = (String) tableModel.getValueAt(selectedRow, 0);
                         String currentPath = (String) tableModel.getValueAt(selectedRow, 1);
-
-                        JPanel panel = new JPanel();
-                        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
-
-                        JTextField versionField = new JTextField(currentVersion);
-                        TextFieldWithBrowseButton fileField = new TextFieldWithBrowseButton();
-                        fileField.setText(currentPath);
-                        fileField.addBrowseFolderListener(new TextBrowseFolderListener(fileDescriptor, project));
-
-
-                        panel.add(new JLabel("FIX Version:"));
-                        panel.add(versionField);
-                        panel.add(new JLabel("Custom Dictionary Path:"));
-                        panel.add(fileField);
-
-                        int result = JOptionPane.showConfirmDialog(mainPanel, panel, "Edit Mapping", JOptionPane.OK_CANCEL_OPTION);
-                        if (result == JOptionPane.OK_OPTION) {
-                            String newVersion = versionField.getText().trim();
-                            String newPath = fileField.getText().trim();
-                            tableModel.setValueAt(newVersion, selectedRow, 0);
-                            tableModel.setValueAt(newPath, selectedRow, 1);
+                        DictionaryMappingEditDialog dialog = new DictionaryMappingEditDialog(
+                                project,
+                                currentVersion,
+                                currentPath,
+                                fileDescriptor
+                        );
+                        if (dialog.showAndGet()) {
+                            tableModel.setValueAt(dialog.getVersion(), selectedRow, 0);
+                            tableModel.setValueAt(dialog.getDictionaryPath(), selectedRow, 1);
                         }
                     }
                 });

--- a/src/main/java/com/rannett/fixplugin/settings/FixViewerSettingsConfigurable.java
+++ b/src/main/java/com/rannett/fixplugin/settings/FixViewerSettingsConfigurable.java
@@ -1,5 +1,6 @@
 package com.rannett.fixplugin.settings;
 
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer;
 import com.intellij.openapi.fileChooser.FileChooserDescriptor;
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
 import com.intellij.openapi.options.Configurable;
@@ -8,6 +9,8 @@ import com.intellij.openapi.ui.TextBrowseFolderListener;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.ui.ToolbarDecorator;
 import com.intellij.ui.table.JBTable;
+import com.rannett.fixplugin.dictionary.FixDictionaryCache;
+import com.rannett.fixplugin.dictionary.FixDictionaryChangeListener;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.Nullable;
 
@@ -107,6 +110,11 @@ public class FixViewerSettingsConfigurable implements Configurable {
     @Override
     public void apply() {
         settingsState.setCustomDictionaryPaths(tableToMap());
+        project.getService(FixDictionaryCache.class).clear();
+        project.getMessageBus()
+                .syncPublisher(FixDictionaryChangeListener.TOPIC)
+                .onDictionariesChanged();
+        DaemonCodeAnalyzer.getInstance(project).restart();
     }
 
     @Override

--- a/src/main/java/com/rannett/fixplugin/ui/FixDualViewEditor.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixDualViewEditor.java
@@ -108,7 +108,12 @@ public class FixDualViewEditor extends UserDataHolderBase implements FileEditor 
         mainPanel.add(tabbedPane, BorderLayout.CENTER);
 
         messageBusConnection = project.getMessageBus().connect(this);
-        messageBusConnection.subscribe(FixDictionaryChangeListener.TOPIC, this::handleDictionaryChange);
+        messageBusConnection.subscribe(FixDictionaryChangeListener.TOPIC, new FixDictionaryChangeListener() {
+            @Override
+            public void onDictionariesChanged() {
+                handleDictionaryChange();
+            }
+        });
 
         // Full rebuild and revalidation on document change
         document.addDocumentListener(new com.intellij.openapi.editor.event.DocumentListener() {

--- a/src/main/java/com/rannett/fixplugin/ui/FixTransposedTableModel.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixTransposedTableModel.java
@@ -294,6 +294,19 @@ public class FixTransposedTableModel extends AbstractTableModel {
         return fixVersion;
     }
 
+    /**
+     * Triggers a repaint so that cached table rows pick up updated dictionary metadata.
+     */
+    public void refreshDictionaryMetadata() {
+        SwingUtilities.invokeLater(() -> {
+            if (getRowCount() > 0) {
+                fireTableRowsUpdated(0, getRowCount() - 1);
+            } else {
+                fireTableDataChanged();
+            }
+        });
+    }
+
     public interface DocumentUpdater {
         void updateTagValueInMessage(String messageId, String tag, int occurrence, String newValue);
     }

--- a/src/main/java/com/rannett/fixplugin/ui/FixTransposedTablePanel.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixTransposedTablePanel.java
@@ -198,6 +198,10 @@ public class FixTransposedTablePanel extends JPanel {
         if (onCellSelectedCallback != null) onCellSelectedCallback.run();
     }
 
+    public String getFixVersion() {
+        return model.getFixVersion();
+    }
+
     public String getSelectedTag() {
         int row = table.getSelectedRow();
         return row >= 0 ? model.getTagAtRow(row) : null;

--- a/src/main/java/com/rannett/fixplugin/ui/FixTransposedTablePanel.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixTransposedTablePanel.java
@@ -159,6 +159,14 @@ public class FixTransposedTablePanel extends JPanel {
         configureColumnWidths();
     }
 
+    /**
+     * Refreshes the rendered metadata so that tag names and enum descriptions reflect the active dictionary.
+     */
+    public void refreshDictionaryMetadata() {
+        model.refreshDictionaryMetadata();
+        table.repaint();
+    }
+
     public void applyTagFilter(Set<String> tags) {
         filteredTags = new LinkedHashSet<>(tags);
         if (filteredTags.isEmpty()) {


### PR DESCRIPTION
## Summary
- introduce a project-level dictionary change topic and clear caches when mappings are updated
- refresh open FIX editors and tool windows so tag names, enums, and validation use the new dictionary immediately

## Testing
- `./gradlew test --no-daemon --console=plain` *(fails: PluginException from PersistentFSConnector in IntelliJ test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914a77c2aa4832c84b0086c5b2d8083)