### PR TITLE
Add multi-dictionary selection across FIX views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix dictionary change event subscription so builds compile with the IntelliJ message bus APIs.
 - Replace the dictionary mapping edit dialog with an IntelliJ DialogWrapper implementation to avoid thread context errors
   when updating dictionaries from the settings panel.
+- Ensure selecting a new default dictionary in settings clears the previous default indicator for that FIX version.
 
 ## [0.0.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 - Display the active dictionary for each open FIX viewer, highlighting modified dictionary locations.
+- Manage bundled dictionaries directly in settings, add multiple custom dictionaries per FIX version, and choose the active one from a new in-viewer combobox that re-parses messages instantly.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ fields for different messages will be shown in the same row, making comparison e
 - **Message Hiding** in the transposed view for large message files
 - **Enumerated Values** suggested as items in the table view
 - **Override Dictionaries** with bespoke ones. Standard Quickfix dictionaries are used.
-- **Dictionary Indicator** shows whether each FIX version uses the default or a modified dictionary directly in the viewers.
+- **Dictionary selector** lists bundled and custom dictionaries per FIX version so you can switch parsing dynamically from the viewers.
+- **Dictionary Indicator** shows whether each FIX version uses the default or a modified dictionary directly in the viewers and lets you mark defaults per FIX version.
 - **Side-by-side diff viewer** for comparing two messages
 - **Language injection** for FIX messages embedded in code strings
 - **FpML Detection** for XML embedded in tags 351 and 213

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ fields for different messages will be shown in the same row, making comparison e
 - **Override Dictionaries** with bespoke ones. Standard Quickfix dictionaries are used.
 - **Dictionary selector** lists bundled and custom dictionaries per FIX version so you can switch parsing dynamically from the viewers.
 - **Dictionary Indicator** shows whether each FIX version uses the default or a modified dictionary directly in the viewers and lets you mark defaults per FIX version.
+- **Default handoff in settings** immediately clears the previous default when you mark another dictionary as preferred for a FIX version, so the table always reflects the active default.
 - **Side-by-side diff viewer** for comparing two messages
 - **Language injection** for FIX messages embedded in code strings
 - **FpML Detection** for XML embedded in tags 351 and 213

--- a/src/main/java/com/rannett/fixplugin/settings/DictionaryMappingEditDialog.java
+++ b/src/main/java/com/rannett/fixplugin/settings/DictionaryMappingEditDialog.java
@@ -10,6 +10,7 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JCheckBox;
 import javax.swing.JTextField;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -22,6 +23,7 @@ public class DictionaryMappingEditDialog extends DialogWrapper {
 
     private final JTextField versionField;
     private final TextFieldWithBrowseButton pathField;
+    private final JCheckBox defaultCheckBox;
     private final JPanel contentPanel;
 
     /**
@@ -35,7 +37,8 @@ public class DictionaryMappingEditDialog extends DialogWrapper {
     public DictionaryMappingEditDialog(@Nullable Project project,
                                        @Nullable String currentVersion,
                                        @Nullable String currentPath,
-                                       FileChooserDescriptor descriptor) {
+                                       FileChooserDescriptor descriptor,
+                                       boolean defaultDictionary) {
         super(project, true);
         setTitle("Edit Mapping");
         versionField = new JTextField(currentVersion != null ? currentVersion : "");
@@ -44,6 +47,7 @@ public class DictionaryMappingEditDialog extends DialogWrapper {
             pathField.addBrowseFolderListener(new TextBrowseFolderListener(descriptor, project));
         }
         pathField.setText(currentPath != null ? currentPath : "");
+        defaultCheckBox = new JCheckBox("Mark as default for this FIX version", defaultDictionary);
         contentPanel = buildContentPanel();
         init();
     }
@@ -68,6 +72,9 @@ public class DictionaryMappingEditDialog extends DialogWrapper {
         constraints.gridy = 3;
         panel.add(pathField, constraints);
 
+        constraints.gridy = 4;
+        panel.add(defaultCheckBox, constraints);
+
         return panel;
     }
 
@@ -88,5 +95,9 @@ public class DictionaryMappingEditDialog extends DialogWrapper {
      */
     public String getDictionaryPath() {
         return pathField.getText().trim();
+    }
+
+    public boolean isDefaultDictionary() {
+        return defaultCheckBox.isSelected();
     }
 }

--- a/src/main/java/com/rannett/fixplugin/settings/FixViewerSettingsConfigurable.java
+++ b/src/main/java/com/rannett/fixplugin/settings/FixViewerSettingsConfigurable.java
@@ -9,6 +9,7 @@ import com.intellij.ui.ToolbarDecorator;
 import com.intellij.ui.table.JBTable;
 import com.rannett.fixplugin.dictionary.FixDictionaryCache;
 import com.rannett.fixplugin.dictionary.FixDictionaryChangeListener;
+import com.rannett.fixplugin.settings.FixViewerSettingsState.DictionaryEntry;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.Nullable;
 
@@ -16,15 +17,16 @@ import javax.swing.BoxLayout;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.table.DefaultTableModel;
-import java.util.HashMap;
-import java.util.Map;
+import javax.swing.table.AbstractTableModel;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 public class FixViewerSettingsConfigurable implements Configurable {
 
     private JPanel mainPanel;
     private JBTable versionTable;
-    private DefaultTableModel tableModel;
+    private DictionaryTableModel tableModel;
     private final FixViewerSettingsState settingsState;
     private final Project project;
 
@@ -43,8 +45,7 @@ public class FixViewerSettingsConfigurable implements Configurable {
     @Override
     public JComponent createComponent() {
         mainPanel = new JPanel();
-        String[] columnNames = {"FIX Version", "Custom Dictionary Path"};
-        tableModel = new DefaultTableModel(columnNames, 0);
+        tableModel = new DictionaryTableModel();
         versionTable = new JBTable(tableModel);
 
         // Setup file chooser descriptor
@@ -54,27 +55,49 @@ public class FixViewerSettingsConfigurable implements Configurable {
 
         // Decorate the table with add/remove/edit
         ToolbarDecorator decorator = ToolbarDecorator.createDecorator(versionTable)
-                .setAddAction(button -> tableModel.addRow(new Object[]{"", ""}))
+                .setAddAction(button -> {
+                    DictionaryMappingEditDialog dialog = new DictionaryMappingEditDialog(
+                            project,
+                            "",
+                            "",
+                            fileDescriptor,
+                            true
+                    );
+                    if (dialog.showAndGet()) {
+                        DictionaryEntry entry = new DictionaryEntry(
+                                dialog.getVersion(),
+                                dialog.getDictionaryPath(),
+                                false,
+                                dialog.isDefaultDictionary()
+                        );
+                        tableModel.addEntry(entry);
+                    }
+                })
                 .setRemoveAction(button -> {
                     int selectedRow = versionTable.getSelectedRow();
                     if (selectedRow != -1) {
-                        tableModel.removeRow(selectedRow);
+                        tableModel.removeEntry(selectedRow);
                     }
                 })
                 .setEditAction(button -> {
                     int selectedRow = versionTable.getSelectedRow();
                     if (selectedRow != -1) {
-                        String currentVersion = (String) tableModel.getValueAt(selectedRow, 0);
-                        String currentPath = (String) tableModel.getValueAt(selectedRow, 1);
+                        DictionaryEntry entry = tableModel.getEntry(selectedRow);
+                        if (entry.isBuiltIn()) {
+                            return;
+                        }
                         DictionaryMappingEditDialog dialog = new DictionaryMappingEditDialog(
                                 project,
-                                currentVersion,
-                                currentPath,
-                                fileDescriptor
+                                entry.getVersion(),
+                                entry.getPath(),
+                                fileDescriptor,
+                                entry.isDefaultDictionary()
                         );
                         if (dialog.showAndGet()) {
-                            tableModel.setValueAt(dialog.getVersion(), selectedRow, 0);
-                            tableModel.setValueAt(dialog.getDictionaryPath(), selectedRow, 1);
+                            entry.setVersion(dialog.getVersion());
+                            entry.setPath(dialog.getDictionaryPath());
+                            entry.setDefaultDictionary(dialog.isDefaultDictionary());
+                            tableModel.updateEntry(selectedRow, entry);
                         }
                     }
                 });
@@ -88,12 +111,12 @@ public class FixViewerSettingsConfigurable implements Configurable {
 
     @Override
     public boolean isModified() {
-        return !settingsState.getCustomDictionaryPaths().equals(tableToMap());
+        return !Objects.equals(settingsState.getDictionaryEntries(), tableModel.getEntries());
     }
 
     @Override
     public void apply() {
-        settingsState.setCustomDictionaryPaths(tableToMap());
+        settingsState.setDictionaryEntries(tableModel.getEntries());
         project.getService(FixDictionaryCache.class).clear();
         project.getMessageBus()
                 .syncPublisher(FixDictionaryChangeListener.TOPIC)
@@ -103,10 +126,7 @@ public class FixViewerSettingsConfigurable implements Configurable {
 
     @Override
     public void reset() {
-        tableModel.setRowCount(0);
-        for (Map.Entry<String, String> entry : settingsState.getCustomDictionaryPaths().entrySet()) {
-            tableModel.addRow(new Object[]{entry.getKey(), entry.getValue()});
-        }
+        tableModel.setEntries(settingsState.getDictionaryEntries());
     }
 
     @Override
@@ -114,15 +134,121 @@ public class FixViewerSettingsConfigurable implements Configurable {
         // No resources to dispose
     }
 
-    private Map<String, String> tableToMap() {
-        Map<String, String> map = new HashMap<>();
-        for (int i = 0; i < tableModel.getRowCount(); i++) {
-            String version = (String) tableModel.getValueAt(i, 0);
-            String path = (String) tableModel.getValueAt(i, 1);
-            if (version != null && !version.trim().isEmpty() && path != null && !path.trim().isEmpty()) {
-                map.put(version.trim(), path.trim());
+    private static final class DictionaryTableModel extends AbstractTableModel {
+        private final String[] columnNames = {"FIX Version", "Dictionary Path", "Default"};
+        private final List<DictionaryEntry> entries = new ArrayList<>();
+
+        @Override
+        public int getRowCount() {
+            return entries.size();
+        }
+
+        @Override
+        public int getColumnCount() {
+            return columnNames.length;
+        }
+
+        @Override
+        public String getColumnName(int column) {
+            return columnNames[column];
+        }
+
+        @Override
+        public Class<?> getColumnClass(int columnIndex) {
+            if (columnIndex == 2) {
+                return Boolean.class;
+            }
+            return String.class;
+        }
+
+        @Override
+        public boolean isCellEditable(int rowIndex, int columnIndex) {
+            DictionaryEntry entry = entries.get(rowIndex);
+            return !entry.isBuiltIn();
+        }
+
+        @Override
+        public Object getValueAt(int rowIndex, int columnIndex) {
+            DictionaryEntry entry = entries.get(rowIndex);
+            return switch (columnIndex) {
+                case 0 -> entry.getVersion();
+                case 1 -> entry.isBuiltIn() ? "Bundled dictionary" : entry.getPath();
+                case 2 -> entry.isDefaultDictionary();
+                default -> "";
+            };
+        }
+
+        @Override
+        public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
+            DictionaryEntry entry = entries.get(rowIndex);
+            if (entry.isBuiltIn()) {
+                return;
+            }
+            if (columnIndex == 0) {
+                entry.setVersion(aValue != null ? aValue.toString() : "");
+            } else if (columnIndex == 1) {
+                entry.setPath(aValue != null ? aValue.toString() : "");
+            } else if (columnIndex == 2) {
+                boolean selected = aValue instanceof Boolean && (Boolean) aValue;
+                entry.setDefaultDictionary(selected);
+                if (selected) {
+                    clearDefaultsForVersion(entry.getVersion(), rowIndex);
+                }
+            }
+            fireTableRowsUpdated(rowIndex, rowIndex);
+        }
+
+        void addEntry(DictionaryEntry entry) {
+            if (entry.isDefaultDictionary()) {
+                clearDefaultsForVersion(entry.getVersion(), -1);
+            }
+            entries.add(entry);
+            fireTableDataChanged();
+        }
+
+        void removeEntry(int index) {
+            if (index < 0 || index >= entries.size()) {
+                return;
+            }
+            if (entries.get(index).isBuiltIn()) {
+                return;
+            }
+            entries.remove(index);
+            fireTableDataChanged();
+        }
+
+        void updateEntry(int index, DictionaryEntry entry) {
+            if (entry.isDefaultDictionary()) {
+                clearDefaultsForVersion(entry.getVersion(), index);
+            }
+            entries.set(index, entry);
+            fireTableRowsUpdated(index, index);
+        }
+
+        DictionaryEntry getEntry(int index) {
+            return entries.get(index);
+        }
+
+        List<DictionaryEntry> getEntries() {
+            return new ArrayList<>(entries);
+        }
+
+        void setEntries(List<DictionaryEntry> newEntries) {
+            entries.clear();
+            entries.addAll(newEntries);
+            fireTableDataChanged();
+        }
+
+        private void clearDefaultsForVersion(String version, int skipIndex) {
+            for (int i = 0; i < entries.size(); i++) {
+                if (i == skipIndex) {
+                    continue;
+                }
+                DictionaryEntry entry = entries.get(i);
+                if (Objects.equals(entry.getVersion(), version)) {
+                    entry.setDefaultDictionary(false);
+                }
             }
         }
-        return map;
     }
 }

--- a/src/main/java/com/rannett/fixplugin/settings/FixViewerSettingsState.java
+++ b/src/main/java/com/rannett/fixplugin/settings/FixViewerSettingsState.java
@@ -7,8 +7,13 @@ import com.intellij.openapi.components.Storage;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service(Service.Level.PROJECT)
 @State(
@@ -19,22 +24,45 @@ import java.util.Map;
 )
 public final class FixViewerSettingsState implements PersistentStateComponent<FixViewerSettingsState> {
 
-    private Map<String, String> customDictionaryPaths = new HashMap<>();
+    private static final List<String> BUILT_IN_VERSIONS = List.of("FIX.4.2", "FIX.4.4", "FIXT.1.1");
+
+    private List<DictionaryEntry> dictionaryEntries = new ArrayList<>();
 
     public static FixViewerSettingsState getInstance(Project project) {
         return project.getService(FixViewerSettingsState.class);
     }
 
-    public Map<String, String> getCustomDictionaryPaths() {
-        return customDictionaryPaths;
+    public List<DictionaryEntry> getDictionaryEntries() {
+        ensureBuiltInDictionariesPresent();
+        return dictionaryEntries;
     }
 
-    public void setCustomDictionaryPaths(Map<String, String> customDictionaryPaths) {
-        this.customDictionaryPaths = customDictionaryPaths;
+    public void setDictionaryEntries(List<DictionaryEntry> dictionaryEntries) {
+        this.dictionaryEntries = new ArrayList<>(dictionaryEntries);
+        ensureBuiltInDictionariesPresent();
     }
 
-    public String getCustomDictionaryPath(String fixVersion) {
-        return customDictionaryPaths.get(fixVersion);
+    public List<DictionaryEntry> getDictionariesForVersion(String fixVersion) {
+        ensureBuiltInDictionariesPresent();
+        return dictionaryEntries.stream()
+                .filter(entry -> entry.getVersion().equals(fixVersion))
+                .collect(Collectors.toList());
+    }
+
+    public DictionaryEntry getDefaultDictionary(String fixVersion) {
+        ensureBuiltInDictionariesPresent();
+        return getDictionariesForVersion(fixVersion).stream()
+                .filter(entry -> entry.isDefaultDictionary() && !entry.isBuiltIn())
+                .findFirst()
+                .orElseGet(() -> getDictionariesForVersion(fixVersion).stream()
+                        .filter(DictionaryEntry::isDefaultDictionary)
+                        .findFirst()
+                        .orElseGet(() -> getDictionariesForVersion(fixVersion).stream()
+                                .filter(entry -> !entry.isBuiltIn())
+                                .findFirst()
+                                .orElseGet(() -> getDictionariesForVersion(fixVersion).stream()
+                                        .findFirst()
+                                        .orElse(null))));
     }
 
     @Override
@@ -44,6 +72,131 @@ public final class FixViewerSettingsState implements PersistentStateComponent<Fi
 
     @Override
     public void loadState(@NotNull FixViewerSettingsState state) {
-        this.customDictionaryPaths = state.customDictionaryPaths;
+        this.dictionaryEntries = new ArrayList<>(state.dictionaryEntries);
+        ensureBuiltInDictionariesPresent();
+    }
+
+    private void ensureBuiltInDictionariesPresent() {
+        if (dictionaryEntries == null) {
+            dictionaryEntries = new ArrayList<>();
+        }
+        Set<String> presentVersions = dictionaryEntries.stream()
+                .filter(DictionaryEntry::isBuiltIn)
+                .map(DictionaryEntry::getVersion)
+                .collect(Collectors.toCollection(HashSet::new));
+        for (String version : BUILT_IN_VERSIONS) {
+            if (!presentVersions.contains(version)) {
+                dictionaryEntries.add(DictionaryEntry.builtIn(version));
+            }
+        }
+        normalizeDefaults();
+    }
+
+    private void normalizeDefaults() {
+        Map<String, List<DictionaryEntry>> grouped = dictionaryEntries.stream()
+                .collect(Collectors.groupingBy(DictionaryEntry::getVersion));
+        for (Map.Entry<String, List<DictionaryEntry>> entry : grouped.entrySet()) {
+            List<DictionaryEntry> versions = entry.getValue();
+            DictionaryEntry preferred = versions.stream()
+                    .filter(e -> e.isDefaultDictionary() && !e.isBuiltIn())
+                    .findFirst()
+                    .orElseGet(() -> versions.stream()
+                            .filter(DictionaryEntry::isDefaultDictionary)
+                            .findFirst()
+                            .orElseGet(() -> versions.stream()
+                                    .filter(e -> !e.isBuiltIn())
+                                    .findFirst()
+                                    .orElseGet(() -> versions.isEmpty() ? null : versions.get(0))));
+            for (DictionaryEntry dictionaryEntry : versions) {
+                dictionaryEntry.setDefaultDictionary(Objects.equals(dictionaryEntry, preferred));
+            }
+        }
+    }
+
+    public static class DictionaryEntry {
+        private String version;
+        private String path;
+        private boolean builtIn;
+        private boolean defaultDictionary;
+
+        public DictionaryEntry() {
+        }
+
+        public DictionaryEntry(String version, String path, boolean builtIn, boolean defaultDictionary) {
+            this.version = version;
+            this.path = path;
+            this.builtIn = builtIn;
+            this.defaultDictionary = defaultDictionary;
+        }
+
+        public static DictionaryEntry builtIn(String version) {
+            return new DictionaryEntry(version, null, true, true);
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        public void setVersion(String version) {
+            this.version = version;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public void setPath(String path) {
+            this.path = path;
+        }
+
+        public boolean isBuiltIn() {
+            return builtIn;
+        }
+
+        public void setBuiltIn(boolean builtIn) {
+            this.builtIn = builtIn;
+        }
+
+        public boolean isDefaultDictionary() {
+            return defaultDictionary;
+        }
+
+        public void setDefaultDictionary(boolean defaultDictionary) {
+            this.defaultDictionary = defaultDictionary;
+        }
+
+        public String getCacheKey() {
+            if (builtIn) {
+                return "BUILTIN:" + version;
+            }
+            return "CUSTOM:" + path;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            DictionaryEntry that = (DictionaryEntry) obj;
+            return builtIn == that.builtIn
+                    && defaultDictionary == that.defaultDictionary
+                    && Objects.equals(version, that.version)
+                    && Objects.equals(path, that.path);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(version, path, builtIn, defaultDictionary);
+        }
+
+        @Override
+        public String toString() {
+            String type = builtIn ? "Built-in" : "Custom";
+            String location = builtIn ? "Bundled" : path;
+            return version + " - " + type + " (" + location + ")";
+        }
     }
 }

--- a/src/main/java/com/rannett/fixplugin/ui/FixCommTimelinePanel.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixCommTimelinePanel.java
@@ -6,6 +6,7 @@ import com.intellij.ui.treeStructure.treetable.ListTreeTableModelOnColumns;
 import com.intellij.ui.treeStructure.treetable.TreeColumnInfo;
 import com.intellij.ui.treeStructure.treetable.TreeTable;
 import com.intellij.util.ui.ColumnInfo;
+import com.rannett.fixplugin.settings.FixViewerSettingsState.DictionaryEntry;
 import com.rannett.fixplugin.util.FixMessageParser;
 import org.jetbrains.annotations.NotNull;
 
@@ -176,7 +177,7 @@ public class FixCommTimelinePanel extends JPanel {
     private MessageNode parseNode(String msg, int index) {
         String begin = extractBeginString(msg);
         try {
-            DataDictionary dd = FixMessageParser.loadDataDictionary(begin, null);
+            DataDictionary dd = FixMessageParser.loadDataDictionary(begin, (DictionaryEntry) null);
             Message parsed = FixMessageParser.parse(msg, dd);
 
             String time = parsed.getHeader().isSetField(52) ? parsed.getHeader().getString(52) : "";

--- a/src/main/java/com/rannett/fixplugin/ui/FixMessageTreePanel.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixMessageTreePanel.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.ui.treeStructure.Tree;
 import com.rannett.fixplugin.util.FixMessageParser;
 import com.rannett.fixplugin.util.FixUtils;
+import com.rannett.fixplugin.settings.FixViewerSettingsState.DictionaryEntry;
 import quickfix.DataDictionary;
 import quickfix.Field;
 import quickfix.FieldMap;
@@ -27,15 +28,21 @@ public class FixMessageTreePanel extends JPanel {
 
     private static final Logger LOG = Logger.getInstance(FixMessageTreePanel.class);
     private final Project project;
+    private DictionaryEntry dictionaryEntry;
 
-    public FixMessageTreePanel(List<String> fixMessages, Project project) {
+    public FixMessageTreePanel(List<String> fixMessages, Project project, DictionaryEntry dictionaryEntry) {
         super(new BorderLayout());
         this.project = project;
+        this.dictionaryEntry = dictionaryEntry;
         buildTree(fixMessages);
     }
 
     public void updateTree(List<String> fixMessages) {
         buildTree(fixMessages);
+    }
+
+    public void setDictionaryEntry(DictionaryEntry dictionaryEntry) {
+        this.dictionaryEntry = dictionaryEntry;
     }
 
     private void buildTree(List<String> fixMessages) {
@@ -44,7 +51,7 @@ public class FixMessageTreePanel extends JPanel {
         String fixVersion = detectFixVersion(fixMessages.isEmpty() ? "" : fixMessages.get(0));
         if (fixVersion == null) fixVersion = "FIXT.1.1";
 
-        DataDictionary dd = FixMessageParser.loadDataDictionary(fixVersion, project);
+        DataDictionary dd = FixMessageParser.loadDataDictionary(fixVersion, dictionaryEntry);
 
         for (String message : fixMessages) {
             message = message.strip();

--- a/src/main/java/com/rannett/fixplugin/ui/FixTransposedTableModel.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixTransposedTableModel.java
@@ -3,6 +3,7 @@ package com.rannett.fixplugin.ui;
 import com.intellij.openapi.project.Project;
 import com.rannett.fixplugin.dictionary.FixDictionaryCache;
 import com.rannett.fixplugin.dictionary.FixTagDictionary;
+import com.rannett.fixplugin.settings.FixViewerSettingsState.DictionaryEntry;
 
 import javax.swing.SwingUtilities;
 import javax.swing.table.AbstractTableModel;
@@ -25,6 +26,7 @@ public class FixTransposedTableModel extends AbstractTableModel {
     private List<String> tagOrder;
     private Map<String, Map<String, String>> transposed;
     private String fixVersion;
+    private DictionaryEntry dictionaryEntry;
     private final DocumentUpdater documentUpdater;
     private final Project project;
 
@@ -233,7 +235,7 @@ public class FixTransposedTableModel extends AbstractTableModel {
             return tag;
         }
         if (columnIndex == 1) {
-            FixTagDictionary dictionary = project.getService(FixDictionaryCache.class).getDictionary(fixVersion);
+            FixTagDictionary dictionary = resolveDictionary();
             String tagName = dictionary.getTagName(tag);
             return tagName != null ? tagName : "";  // Show empty string instead of null
         }
@@ -292,6 +294,21 @@ public class FixTransposedTableModel extends AbstractTableModel {
 
     public String getFixVersion() {
         return fixVersion;
+    }
+
+    public DictionaryEntry getDictionaryEntry() {
+        return dictionaryEntry;
+    }
+
+    public void setDictionaryEntry(DictionaryEntry dictionaryEntry) {
+        this.dictionaryEntry = dictionaryEntry;
+    }
+
+    private FixTagDictionary resolveDictionary() {
+        if (project == null) {
+            return FixTagDictionary.fromBuiltInVersion(fixVersion);
+        }
+        return project.getService(FixDictionaryCache.class).getDictionary(dictionaryEntry, fixVersion);
     }
 
     /**

--- a/src/main/java/com/rannett/fixplugin/ui/TagFilterDialog.java
+++ b/src/main/java/com/rannett/fixplugin/ui/TagFilterDialog.java
@@ -4,6 +4,7 @@ import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.project.Project;
 import com.rannett.fixplugin.dictionary.FixDictionaryCache;
 import com.rannett.fixplugin.dictionary.FixTagDictionary;
+import com.rannett.fixplugin.settings.FixViewerSettingsState.DictionaryEntry;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
@@ -22,11 +23,12 @@ public class TagFilterDialog extends DialogWrapper {
     public TagFilterDialog(@Nullable Project project,
                            Collection<String> tags,
                            Collection<String> initiallySelected,
-                           String fixVersion) {
+                           String fixVersion,
+                           DictionaryEntry dictionaryEntry) {
         super(project, true);
         FixTagDictionary dict = null;
         if (project != null) {
-            dict = project.getService(FixDictionaryCache.class).getDictionary(fixVersion);
+            dict = project.getService(FixDictionaryCache.class).getDictionary(dictionaryEntry, fixVersion);
         }
         for (String tag : tags) {
             String name = dict != null ? dict.getTagName(tag) : null;

--- a/src/test/java/com/rannett/fixplugin/dictionary/FixDictionaryCacheTest.java
+++ b/src/test/java/com/rannett/fixplugin/dictionary/FixDictionaryCacheTest.java
@@ -2,6 +2,7 @@ package com.rannett.fixplugin.dictionary;
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 import com.rannett.fixplugin.settings.FixViewerSettingsState;
+import com.rannett.fixplugin.settings.FixViewerSettingsState.DictionaryEntry;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -11,13 +12,13 @@ public class FixDictionaryCacheTest extends BasePlatformTestCase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        FixViewerSettingsState.getInstance(getProject()).getCustomDictionaryPaths().clear();
+        FixViewerSettingsState.getInstance(getProject()).setDictionaryEntries(new java.util.ArrayList<>());
     }
 
     @Override
     protected void tearDown() throws Exception {
         try {
-            FixViewerSettingsState.getInstance(getProject()).getCustomDictionaryPaths().clear();
+            FixViewerSettingsState.getInstance(getProject()).setDictionaryEntries(new java.util.ArrayList<>());
         } finally {
             super.tearDown();
         }
@@ -28,7 +29,9 @@ public class FixDictionaryCacheTest extends BasePlatformTestCase {
         Files.writeString(file.toPath(), "<dictionary>\n<field number=\"1\" name=\"One\" type=\"STRING\"/>\n</dictionary>");
 
         FixViewerSettingsState settings = FixViewerSettingsState.getInstance(getProject());
-        settings.getCustomDictionaryPaths().put("FIX.4.2", file.getAbsolutePath());
+        java.util.List<DictionaryEntry> entries = new java.util.ArrayList<>(settings.getDictionaryEntries());
+        entries.add(new DictionaryEntry("FIX.4.2", file.getAbsolutePath(), false, true));
+        settings.setDictionaryEntries(entries);
 
         FixDictionaryCache cache = new FixDictionaryCache(getProject());
         FixTagDictionary dict = cache.getDictionary("FIX.4.2");
@@ -39,7 +42,9 @@ public class FixDictionaryCacheTest extends BasePlatformTestCase {
         File file1 = File.createTempFile("dict1", ".xml");
         Files.writeString(file1.toPath(), "<dictionary>\n<field number=\"1\" name=\"First\" type=\"STRING\"/>\n</dictionary>");
         FixViewerSettingsState settings = FixViewerSettingsState.getInstance(getProject());
-        settings.getCustomDictionaryPaths().put("FIX.4.3", file1.getAbsolutePath());
+        java.util.List<DictionaryEntry> entries = new java.util.ArrayList<>(settings.getDictionaryEntries());
+        entries.add(new DictionaryEntry("FIX.4.3", file1.getAbsolutePath(), false, true));
+        settings.setDictionaryEntries(entries);
 
         FixDictionaryCache cache = new FixDictionaryCache(getProject());
         FixTagDictionary first = cache.getDictionary("FIX.4.3");
@@ -47,10 +52,13 @@ public class FixDictionaryCacheTest extends BasePlatformTestCase {
 
         File file2 = File.createTempFile("dict2", ".xml");
         Files.writeString(file2.toPath(), "<dictionary>\n<field number=\"1\" name=\"Second\" type=\"STRING\"/>\n</dictionary>");
-        settings.getCustomDictionaryPaths().put("FIX.4.3", file2.getAbsolutePath());
+        entries = new java.util.ArrayList<>(settings.getDictionaryEntries());
+        entries.removeIf(entry -> "FIX.4.3".equals(entry.getVersion()) && !entry.isBuiltIn());
+        entries.add(new DictionaryEntry("FIX.4.3", file2.getAbsolutePath(), false, true));
+        settings.setDictionaryEntries(entries);
 
         FixTagDictionary second = cache.getDictionary("FIX.4.3");
-        assertSame(first, second);
-        assertEquals("First", second.getTagName("1"));
+        assertNotSame(first, second);
+        assertEquals("Second", second.getTagName("1"));
     }
 }

--- a/src/test/java/com/rannett/fixplugin/settings/FixViewerSettingsConfigurableTest.java
+++ b/src/test/java/com/rannett/fixplugin/settings/FixViewerSettingsConfigurableTest.java
@@ -1,0 +1,50 @@
+package com.rannett.fixplugin.settings;
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import com.rannett.fixplugin.settings.FixViewerSettingsState.DictionaryEntry;
+
+import javax.swing.event.TableModelEvent;
+import javax.swing.table.AbstractTableModel;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FixViewerSettingsConfigurableTest extends BasePlatformTestCase {
+
+    public void testSelectingNewDefaultClearsPreviousRowFlag() throws Exception {
+        Class<?> modelClass = Class.forName("com.rannett.fixplugin.settings.FixViewerSettingsConfigurable$DictionaryTableModel");
+        Constructor<?> constructor = modelClass.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        AbstractTableModel model = (AbstractTableModel) constructor.newInstance();
+
+        Method setEntries = modelClass.getDeclaredMethod("setEntries", List.class);
+        setEntries.setAccessible(true);
+        Method getEntry = modelClass.getDeclaredMethod("getEntry", int.class);
+        getEntry.setAccessible(true);
+
+        List<DictionaryEntry> rows = new ArrayList<>();
+        rows.add(DictionaryEntry.builtIn("FIX.4.2"));
+        rows.add(new DictionaryEntry("FIX.4.2", "/tmp/custom.xml", false, false));
+        setEntries.invoke(model, rows);
+
+        List<TableModelEvent> events = new ArrayList<>();
+        model.addTableModelListener(events::add);
+
+        model.setValueAt(Boolean.TRUE, 1, 2);
+
+        DictionaryEntry clearedDefault = (DictionaryEntry) getEntry.invoke(model, 0);
+        DictionaryEntry selectedDefault = (DictionaryEntry) getEntry.invoke(model, 1);
+
+        assertFalse("Previous default row should be cleared", clearedDefault.isDefaultDictionary());
+        assertTrue("Newly selected row should be default", selectedDefault.isDefaultDictionary());
+
+        boolean clearedRowUpdated = events.stream()
+                .anyMatch(event -> event.getFirstRow() <= 0 && event.getLastRow() >= 0);
+        boolean selectedRowUpdated = events.stream()
+                .anyMatch(event -> event.getFirstRow() <= 1 && event.getLastRow() >= 1);
+
+        assertTrue("Row losing default should trigger an update", clearedRowUpdated);
+        assertTrue("Row gaining default should trigger an update", selectedRowUpdated);
+    }
+}

--- a/src/test/java/com/rannett/fixplugin/ui/FixTransposedTableModelDictionaryTest.java
+++ b/src/test/java/com/rannett/fixplugin/ui/FixTransposedTableModelDictionaryTest.java
@@ -1,0 +1,44 @@
+package com.rannett.fixplugin.ui;
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import com.rannett.fixplugin.settings.FixViewerSettingsState;
+import com.rannett.fixplugin.settings.FixViewerSettingsState.DictionaryEntry;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FixTransposedTableModelDictionaryTest extends BasePlatformTestCase {
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        FixViewerSettingsState.getInstance(getProject()).setDictionaryEntries(new ArrayList<>());
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        try {
+            FixViewerSettingsState.getInstance(getProject()).setDictionaryEntries(new ArrayList<>());
+        } finally {
+            super.tearDown();
+        }
+    }
+
+    public void testSwitchingDictionariesUpdatesNames() throws Exception {
+        File customDictionary = File.createTempFile("custom-dict", ".xml");
+        Files.writeString(customDictionary.toPath(), "<dictionary>\n<field number=\"999\" name=\"CustomTag\" type=\"STRING\"/>\n</dictionary>");
+        DictionaryEntry customEntry = new DictionaryEntry("FIX.4.2", customDictionary.getAbsolutePath(), false, true);
+
+        List<String> messages = List.of("8=FIX.4.2|35=A|999=value|10=000|");
+        FixTransposedTableModel model = new FixTransposedTableModel(messages, (id, tag, occ, value) -> { }, getProject());
+
+        int row = model.getRowForTag("999");
+        assertTrue(row >= 0);
+        assertEquals("", model.getValueAt(row, 1));
+
+        model.setDictionaryEntry(customEntry);
+        assertEquals("CustomTag", model.getValueAt(row, 1));
+    }
+}

--- a/src/test/java/com/rannett/fixplugin/util/FixMessageParserTest.java
+++ b/src/test/java/com/rannett/fixplugin/util/FixMessageParserTest.java
@@ -1,6 +1,7 @@
 package com.rannett.fixplugin.util;
 
 import org.junit.Test;
+import com.rannett.fixplugin.settings.FixViewerSettingsState.DictionaryEntry;
 import quickfix.DataDictionary;
 import quickfix.Message;
 
@@ -11,7 +12,7 @@ public class FixMessageParserTest {
     @Test
     public void testParsePipeDelimitedMessage() throws Exception {
         String msg = "8=FIX.4.2|9=65|35=0|49=AAA|56=BBB|10=000|";
-        DataDictionary dd = FixMessageParser.loadDataDictionary("FIX.4.2", null);
+        DataDictionary dd = FixMessageParser.loadDataDictionary("FIX.4.2", (DictionaryEntry) null);
         Message m = FixMessageParser.parse(msg, dd);
         assertEquals("FIX.4.2", m.getHeader().getString(8));
         assertEquals("0", m.getHeader().getString(35));
@@ -20,7 +21,7 @@ public class FixMessageParserTest {
     @Test
     public void testParseSohDelimitedMessage() throws Exception {
         String msg = "8=FIX.4.4\u00019=12\u000135=0\u000110=000\u0001";
-        DataDictionary dd = FixMessageParser.loadDataDictionary("FIX.4.4", null);
+        DataDictionary dd = FixMessageParser.loadDataDictionary("FIX.4.4", (DictionaryEntry) null);
         Message m = FixMessageParser.parse(msg, dd);
         assertEquals("FIX.4.4", m.getHeader().getString(8));
         assertEquals("0", m.getHeader().getString(35));
@@ -29,7 +30,7 @@ public class FixMessageParserTest {
     @Test
     public void testBuildMessageLabel() throws Exception {
         String msg = "8=FIX.4.2|9=65|35=A|49=S|56=T|34=2|52=20200101-00:00:00.000|10=000|";
-        DataDictionary dd = FixMessageParser.loadDataDictionary("FIX.4.2", null);
+        DataDictionary dd = FixMessageParser.loadDataDictionary("FIX.4.2", (DictionaryEntry) null);
         Message m = FixMessageParser.parse(msg, dd);
         String label = FixMessageParser.buildMessageLabel(m, dd);
         assertTrue(label.contains("Logon"));
@@ -40,7 +41,7 @@ public class FixMessageParserTest {
 
     @Test
     public void testLoadFallbackDictionary() throws Exception {
-        DataDictionary dd = FixMessageParser.loadDataDictionary("NONEXISTENT", null);
+        DataDictionary dd = FixMessageParser.loadDataDictionary("NONEXISTENT", (DictionaryEntry) null);
         assertNotNull(dd);
         Message m = FixMessageParser.parse("8=FIX.5.0|9=12|35=0|10=000|", dd);
         assertEquals("0", m.getHeader().getString(35));


### PR DESCRIPTION
## Summary
- list bundled dictionaries alongside custom entries in settings with default flags
- add per-message dictionary selection comboboxes that reparse views when changed
- refresh dictionary caching and parsing utilities plus new coverage for switching dictionaries

## Testing
- ./gradlew test --console=plain --no-daemon --stacktrace


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929aa6f7fa8832cbdfef0d0e797d90e)