### PR TITLE
Add FIX dictionary tree viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 - Display the active dictionary for each open FIX viewer, highlighting modified dictionary locations.
+- Dictionary Tree Viewer for browsing FIX dictionaries with synchronized detail panes.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ fields for different messages will be shown in the same row, making comparison e
 - **Tooltips** showing tag descriptions (e.g., `35=8` → *Execution Report*)
 - **Transposed View** to make reading messages easier including filtering and field selection
 - **Tree View** to navigate message structure including groups
+- **Dictionary Tree Viewer** to browse FIX dictionaries with synced details
 - **Message Hiding** in the transposed view for large message files
 - **Enumerated Values** suggested as items in the table view
 - **Override Dictionaries** with bespoke ones. Standard Quickfix dictionaries are used.

--- a/src/main/java/com/rannett/fixplugin/ui/dictionary/FixDictionaryDetector.java
+++ b/src/main/java/com/rannett/fixplugin/ui/dictionary/FixDictionaryDetector.java
@@ -1,0 +1,85 @@
+package com.rannett.fixplugin.ui.dictionary;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.vfs.VirtualFile;
+
+import java.io.BufferedInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Utility class for detecting whether a file is likely to be a FIX dictionary.
+ */
+public final class FixDictionaryDetector {
+
+    private static final Logger LOG = Logger.getInstance(FixDictionaryDetector.class);
+
+    /**
+     * Flag used to force the dictionary viewer even when automatic detection fails.
+     */
+    public static final Key<Boolean> FORCE_DICTIONARY_VIEWER = Key.create("fix.dictionary.viewer.force");
+
+    private static final int PROBE_LENGTH = 2048;
+
+    private FixDictionaryDetector() {
+    }
+
+    /**
+     * Determines whether the provided file is probably a FIX dictionary.
+     *
+     * @param file file to inspect
+     * @return {@code true} when the file content or name matches FIX dictionary patterns
+     */
+    public static boolean isLikelyFixDictionary(VirtualFile file) {
+        if (Boolean.TRUE.equals(file.getUserData(FORCE_DICTIONARY_VIEWER))) {
+            return true;
+        }
+
+        if (file.getExtension() == null) {
+            return false;
+        }
+
+        String extension = file.getExtension().toLowerCase();
+        if (!"xml".equals(extension)) {
+            return false;
+        }
+
+        if (file.getName().toLowerCase().startsWith("fix")) {
+            return true;
+        }
+
+        String probe = readProbe(file);
+        if (probe.isEmpty()) {
+            return false;
+        }
+
+        if (probe.contains("<fix")) {
+            return true;
+        }
+
+        if (probe.contains("<messages") && probe.contains("msgtype")) {
+            return true;
+        }
+
+        if (probe.contains("<fields") && probe.contains("number\"")) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static String readProbe(VirtualFile file) {
+        try (InputStream inputStream = new BufferedInputStream(file.getInputStream())) {
+            byte[] buffer = new byte[PROBE_LENGTH];
+            int read = inputStream.read(buffer);
+            if (read <= 0) {
+                return "";
+            }
+            return new String(buffer, 0, read, StandardCharsets.UTF_8).toLowerCase();
+        } catch (Exception e) {
+            LOG.debug("Unable to read dictionary probe from file: " + file.getName(), e);
+            return "";
+        }
+    }
+}

--- a/src/main/java/com/rannett/fixplugin/ui/dictionary/FixDictionaryFileEditor.java
+++ b/src/main/java/com/rannett/fixplugin/ui/dictionary/FixDictionaryFileEditor.java
@@ -1,0 +1,150 @@
+package com.rannett.fixplugin.ui.dictionary;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.fileEditor.FileEditorLocation;
+import com.intellij.openapi.fileEditor.FileEditorState;
+import com.intellij.openapi.fileEditor.FileEditorStateLevel;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.UserDataHolderBase;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import java.awt.BorderLayout;
+import java.beans.PropertyChangeListener;
+import java.io.InputStream;
+
+/**
+ * File editor providing the structured FIX dictionary viewer.
+ */
+public class FixDictionaryFileEditor extends UserDataHolderBase implements FileEditor {
+
+    private static final Logger LOG = Logger.getInstance(FixDictionaryFileEditor.class);
+
+    private final VirtualFile file;
+    private final JPanel component;
+
+    /**
+     * Creates a new dictionary file editor for the provided file.
+     *
+     * @param project current project
+     * @param file    dictionary file to render
+     */
+    public FixDictionaryFileEditor(@NotNull Project project, @NotNull VirtualFile file) {
+        this.file = file;
+        this.component = new JPanel(new BorderLayout());
+        buildUi();
+    }
+
+    private void buildUi() {
+        try (InputStream inputStream = file.getInputStream()) {
+            FixDictionaryTreePanel panel = new FixDictionaryTreePanel(file.getPresentableUrl());
+            panel.build(inputStream);
+            component.removeAll();
+            component.add(panel, BorderLayout.CENTER);
+        } catch (Exception e) {
+            LOG.warn("Failed to render dictionary viewer for " + file.getName(), e);
+            component.removeAll();
+            component.add(new javax.swing.JLabel("Unable to render dictionary: " + e.getMessage()), BorderLayout.CENTER);
+        }
+    }
+
+    @Override
+    /**
+     * Provides the main UI component.
+     *
+     * @return editor component
+     */
+    public @NotNull JComponent getComponent() {
+        return component;
+    }
+
+    @Override
+    /**
+     * Returns the preferred focus component.
+     *
+     * @return focus target
+     */
+    public @Nullable JComponent getPreferredFocusedComponent() {
+        return component;
+    }
+
+    @Override
+    /**
+     * Identifies this editor type.
+     *
+     * @return editor name
+     */
+    public @NotNull String getName() {
+        return "FIX Dictionary Viewer";
+    }
+
+    @Override
+    /**
+     * {@inheritDoc}
+     */
+    public void setState(@NotNull FileEditorState state) {
+    }
+
+    @Override
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isModified() {
+        return false;
+    }
+
+    @Override
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isValid() {
+        return file.isValid();
+    }
+
+    @Override
+    /**
+     * {@inheritDoc}
+     */
+    public void selectNotify() {
+    }
+
+    @Override
+    /**
+     * {@inheritDoc}
+     */
+    public void deselectNotify() {
+    }
+
+    @Override
+    /**
+     * {@inheritDoc}
+     */
+    public void addPropertyChangeListener(@NotNull PropertyChangeListener listener) {
+    }
+
+    @Override
+    /**
+     * {@inheritDoc}
+     */
+    public void removePropertyChangeListener(@NotNull PropertyChangeListener listener) {
+    }
+
+    @Override
+    /**
+     * {@inheritDoc}
+     */
+    public @Nullable FileEditorLocation getCurrentLocation() {
+        return null;
+    }
+
+    @Override
+    /**
+     * {@inheritDoc}
+     */
+    public void dispose() {
+    }
+}

--- a/src/main/java/com/rannett/fixplugin/ui/dictionary/FixDictionaryFileEditorProvider.java
+++ b/src/main/java/com/rannett/fixplugin/ui/dictionary/FixDictionaryFileEditorProvider.java
@@ -1,0 +1,47 @@
+package com.rannett.fixplugin.ui.dictionary;
+
+import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.fileEditor.FileEditorPolicy;
+import com.intellij.openapi.fileEditor.FileEditorProvider;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+
+    /**
+     * File editor provider that replaces XML dictionaries with the structured dictionary viewer.
+     */
+    public class FixDictionaryFileEditorProvider implements FileEditorProvider, DumbAware {
+
+        @Override
+        /**
+         * {@inheritDoc}
+         */
+        public boolean accept(@NotNull Project project, @NotNull VirtualFile file) {
+            return FixDictionaryDetector.isLikelyFixDictionary(file);
+        }
+
+        @Override
+        /**
+         * {@inheritDoc}
+         */
+        public @NotNull FileEditor createEditor(@NotNull Project project, @NotNull VirtualFile file) {
+            return new FixDictionaryFileEditor(project, file);
+        }
+
+        @Override
+        /**
+         * {@inheritDoc}
+         */
+        public @NotNull String getEditorTypeId() {
+            return "fix-dictionary-viewer";
+        }
+
+        @Override
+        /**
+         * {@inheritDoc}
+         */
+        public @NotNull FileEditorPolicy getPolicy() {
+            return FileEditorPolicy.PLACE_BEFORE_DEFAULT_EDITOR;
+        }
+    }

--- a/src/main/java/com/rannett/fixplugin/ui/dictionary/FixDictionaryNodeData.java
+++ b/src/main/java/com/rannett/fixplugin/ui/dictionary/FixDictionaryNodeData.java
@@ -1,0 +1,273 @@
+package com.rannett.fixplugin.ui.dictionary;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Metadata attached to each tree node in the FIX dictionary browser.
+ */
+public class FixDictionaryNodeData {
+
+    public enum NodeType {
+        ROOT,
+        SECTION,
+        MESSAGE,
+        COMPONENT,
+        GROUP,
+        FIELD
+    }
+
+    private final NodeType type;
+    private final String displayName;
+    private final String name;
+    private final String tagNumber;
+    private final String fixType;
+    private final String messageType;
+    private final boolean required;
+    private final String description;
+    private final String source;
+    private final Map<String, String> enums;
+
+    private FixDictionaryNodeData(Builder builder) {
+        this.type = builder.type;
+        this.displayName = builder.displayName;
+        this.name = builder.name;
+        this.tagNumber = builder.tagNumber;
+        this.fixType = builder.fixType;
+        this.messageType = builder.messageType;
+        this.required = builder.required;
+        this.description = builder.description;
+        this.source = builder.source;
+        this.enums = builder.enums;
+    }
+
+    /**
+     * Returns the node type classification.
+     *
+     * @return node category
+     */
+    public NodeType getType() {
+        return type;
+    }
+
+    /**
+     * Node label displayed in the tree.
+     *
+     * @return display label
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * Raw name value from the dictionary entry.
+     *
+     * @return dictionary name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Tag number for field or group entries.
+     *
+     * @return numeric tag as a string
+     */
+    public String getTagNumber() {
+        return tagNumber;
+    }
+
+    /**
+     * FIX data type for a field.
+     *
+     * @return field type
+     */
+    public String getFixType() {
+        return fixType;
+    }
+
+    /**
+     * Message type code when applicable.
+     *
+     * @return message type value
+     */
+    public String getMessageType() {
+        return messageType;
+    }
+
+    /**
+     * Indicates if the dictionary element is required.
+     *
+     * @return {@code true} when required
+     */
+    public boolean isRequired() {
+        return required;
+    }
+
+    /**
+     * Detailed description of the entry, if available.
+     *
+     * @return description text
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Path or logical source of the dictionary entry.
+     *
+     * @return source label
+     */
+    public String getSource() {
+        return source;
+    }
+
+    /**
+     * Enumerated values for a field keyed by enum value.
+     *
+     * @return enumeration map
+     */
+    public Map<String, String> getEnums() {
+        return enums;
+    }
+
+    @Override
+    public String toString() {
+        return displayName;
+    }
+
+    /**
+     * Builder for {@link FixDictionaryNodeData} instances.
+     */
+    public static class Builder {
+        private NodeType type = NodeType.ROOT;
+        private String displayName = "";
+        private String name = "";
+        private String tagNumber;
+        private String fixType;
+        private String messageType;
+        private boolean required;
+        private String description;
+        private String source;
+        private Map<String, String> enums = new LinkedHashMap<>();
+
+        /**
+         * Sets the node type.
+         *
+         * @param type node category
+         * @return builder instance
+         */
+        public Builder withType(NodeType type) {
+            this.type = type;
+            return this;
+        }
+
+        /**
+         * Sets the tree display label.
+         *
+         * @param displayName label to render
+         * @return builder instance
+         */
+        public Builder withDisplayName(String displayName) {
+            this.displayName = displayName;
+            return this;
+        }
+
+        /**
+         * Sets the underlying dictionary name.
+         *
+         * @param name dictionary name
+         * @return builder instance
+         */
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Sets the FIX tag number.
+         *
+         * @param tagNumber numeric tag
+         * @return builder instance
+         */
+        public Builder withTagNumber(String tagNumber) {
+            this.tagNumber = tagNumber;
+            return this;
+        }
+
+        /**
+         * Sets the FIX data type.
+         *
+         * @param fixType field type
+         * @return builder instance
+         */
+        public Builder withFixType(String fixType) {
+            this.fixType = fixType;
+            return this;
+        }
+
+        /**
+         * Sets the message type code.
+         *
+         * @param messageType message type value
+         * @return builder instance
+         */
+        public Builder withMessageType(String messageType) {
+            this.messageType = messageType;
+            return this;
+        }
+
+        /**
+         * Sets whether the entry is required.
+         *
+         * @param required required flag
+         * @return builder instance
+         */
+        public Builder withRequired(boolean required) {
+            this.required = required;
+            return this;
+        }
+
+        /**
+         * Sets the description text.
+         *
+         * @param description description value
+         * @return builder instance
+         */
+        public Builder withDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        /**
+         * Sets the dictionary source label.
+         *
+         * @param source source description
+         * @return builder instance
+         */
+        public Builder withSource(String source) {
+            this.source = source;
+            return this;
+        }
+
+        /**
+         * Sets the enumerated values.
+         *
+         * @param enums enumeration map
+         * @return builder instance
+         */
+        public Builder withEnums(Map<String, String> enums) {
+            this.enums = enums;
+            return this;
+        }
+
+        /**
+         * Builds the immutable {@link FixDictionaryNodeData} instance.
+         *
+         * @return constructed node metadata
+         */
+        public FixDictionaryNodeData build() {
+            return new FixDictionaryNodeData(this);
+        }
+    }
+}

--- a/src/main/java/com/rannett/fixplugin/ui/dictionary/FixDictionaryTreeModelBuilder.java
+++ b/src/main/java/com/rannett/fixplugin/ui/dictionary/FixDictionaryTreeModelBuilder.java
@@ -1,0 +1,357 @@
+package com.rannett.fixplugin.ui.dictionary;
+
+import org.jetbrains.annotations.NotNull;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.InputStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Builds a Swing {@link javax.swing.JTree} model representing a FIX dictionary.
+ */
+public class FixDictionaryTreeModelBuilder {
+
+    private final String sourceLabel;
+
+    /**
+     * Creates a new builder that labels nodes with the provided source.
+     *
+     * @param sourceLabel dictionary source label
+     */
+    public FixDictionaryTreeModelBuilder(String sourceLabel) {
+        this.sourceLabel = sourceLabel;
+    }
+
+    /**
+     * Parses the provided input stream into a tree of {@link DefaultMutableTreeNode} instances.
+     *
+     * @param inputStream dictionary input
+     * @return root tree node with child sections
+     * @throws Exception if parsing fails
+     */
+    public DefaultMutableTreeNode buildTree(@NotNull InputStream inputStream) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document document = builder.parse(inputStream);
+
+        Element root = document.getDocumentElement();
+        Map<String, FieldDefinition> fieldsByName = parseFields(root);
+        Map<String, Element> componentsByName = parseComponents(root);
+
+        DefaultMutableTreeNode rootNode = new DefaultMutableTreeNode(
+                new FixDictionaryNodeData.Builder()
+                        .withDisplayName("FIX Dictionary")
+                        .withSource(sourceLabel)
+                        .withType(FixDictionaryNodeData.NodeType.ROOT)
+                        .build()
+        );
+
+        DefaultMutableTreeNode messagesNode = new DefaultMutableTreeNode(
+                new FixDictionaryNodeData.Builder()
+                        .withDisplayName("Messages")
+                        .withType(FixDictionaryNodeData.NodeType.SECTION)
+                        .withSource(sourceLabel)
+                        .build());
+        addMessages(root, messagesNode, fieldsByName, componentsByName);
+        rootNode.add(messagesNode);
+
+        DefaultMutableTreeNode componentsNode = new DefaultMutableTreeNode(
+                new FixDictionaryNodeData.Builder()
+                        .withDisplayName("Components")
+                        .withType(FixDictionaryNodeData.NodeType.SECTION)
+                        .withSource(sourceLabel)
+                        .build());
+        addComponents(componentsNode, componentsByName, fieldsByName);
+        rootNode.add(componentsNode);
+
+        DefaultMutableTreeNode fieldsNode = new DefaultMutableTreeNode(
+                new FixDictionaryNodeData.Builder()
+                        .withDisplayName("Fields")
+                        .withType(FixDictionaryNodeData.NodeType.SECTION)
+                        .withSource(sourceLabel)
+                        .build());
+        addFields(fieldsNode, fieldsByName);
+        rootNode.add(fieldsNode);
+
+        return rootNode;
+    }
+
+    private Map<String, FieldDefinition> parseFields(Element root) {
+        Map<String, FieldDefinition> map = new LinkedHashMap<>();
+        Element fields = firstChild(root, "fields");
+        if (fields == null) {
+            return map;
+        }
+
+        NodeList childNodes = fields.getChildNodes();
+        for (int i = 0; i < childNodes.getLength(); i++) {
+            Node node = childNodes.item(i);
+            if (!(node instanceof Element element)) {
+                continue;
+            }
+            if (!"field".equals(element.getTagName())) {
+                continue;
+            }
+
+            String name = element.getAttribute("name");
+            if (name == null || name.isEmpty()) {
+                continue;
+            }
+            FieldDefinition definition = new FieldDefinition();
+            definition.name = name;
+            definition.number = element.getAttribute("number");
+            definition.type = element.getAttribute("type");
+            definition.description = element.getAttribute("description");
+            definition.enums = parseEnums(element);
+            map.put(name, definition);
+        }
+
+        return map;
+    }
+
+    private Map<String, Element> parseComponents(Element root) {
+        Map<String, Element> map = new LinkedHashMap<>();
+        Element components = firstChild(root, "components");
+        if (components == null) {
+            return map;
+        }
+        NodeList childNodes = components.getChildNodes();
+        for (int i = 0; i < childNodes.getLength(); i++) {
+            Node node = childNodes.item(i);
+            if (!(node instanceof Element element)) {
+                continue;
+            }
+            if (!"component".equals(element.getTagName())) {
+                continue;
+            }
+            String name = element.getAttribute("name");
+            if (name == null || name.isEmpty()) {
+                continue;
+            }
+            map.put(name, element);
+        }
+        return map;
+    }
+
+    private void addMessages(Element root, DefaultMutableTreeNode messagesNode, Map<String, FieldDefinition> fieldsByName,
+                             Map<String, Element> componentsByName) {
+        Element header = firstChild(root, "header");
+        Element trailer = firstChild(root, "trailer");
+        Element messages = firstChild(root, "messages");
+        if (messages == null) {
+            return;
+        }
+        NodeList children = messages.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node node = children.item(i);
+            if (!(node instanceof Element element)) {
+                continue;
+            }
+            if (!"message".equals(element.getTagName())) {
+                continue;
+            }
+            String name = element.getAttribute("name");
+            String type = element.getAttribute("msgtype");
+            String display = type != null && !type.isEmpty() ? type + " – " + name : name;
+
+            FixDictionaryNodeData nodeData = new FixDictionaryNodeData.Builder()
+                    .withType(FixDictionaryNodeData.NodeType.MESSAGE)
+                    .withName(name)
+                    .withDisplayName(display)
+                    .withMessageType(type)
+                    .withSource(sourceLabel)
+                    .build();
+            DefaultMutableTreeNode messageNode = new DefaultMutableTreeNode(nodeData);
+            messagesNode.add(messageNode);
+
+            if (header != null) {
+                messageNode.add(buildSectionNode("Header", header, fieldsByName, componentsByName));
+            }
+
+            messageNode.add(buildSectionNode("Body", element, fieldsByName, componentsByName));
+
+            if (trailer != null) {
+                messageNode.add(buildSectionNode("Trailer", trailer, fieldsByName, componentsByName));
+            }
+        }
+    }
+
+    private void addComponents(DefaultMutableTreeNode parent, Map<String, Element> componentsByName,
+                               Map<String, FieldDefinition> fieldsByName) {
+        for (Map.Entry<String, Element> entry : componentsByName.entrySet()) {
+            String name = entry.getKey();
+            Element element = entry.getValue();
+
+            DefaultMutableTreeNode componentNode = new DefaultMutableTreeNode(new FixDictionaryNodeData.Builder()
+                    .withType(FixDictionaryNodeData.NodeType.COMPONENT)
+                    .withName(name)
+                    .withDisplayName("Component: " + name)
+                    .withSource(sourceLabel)
+                    .build());
+
+            addMembers(componentNode, element, fieldsByName, componentsByName);
+            parent.add(componentNode);
+        }
+    }
+
+    private void addFields(DefaultMutableTreeNode parent, Map<String, FieldDefinition> fieldsByName) {
+        for (FieldDefinition definition : fieldsByName.values()) {
+            String display = definition.number != null && !definition.number.isEmpty()
+                    ? definition.name + " (" + definition.number + ")"
+                    : definition.name;
+            FixDictionaryNodeData data = new FixDictionaryNodeData.Builder()
+                    .withType(FixDictionaryNodeData.NodeType.FIELD)
+                    .withName(definition.name)
+                    .withDisplayName(display)
+                    .withTagNumber(definition.number)
+                    .withFixType(definition.type)
+                    .withDescription(definition.description)
+                    .withEnums(definition.enums)
+                    .withSource(sourceLabel)
+                    .build();
+            parent.add(new DefaultMutableTreeNode(data));
+        }
+    }
+
+    private DefaultMutableTreeNode buildSectionNode(String title, Element element,
+                                                    Map<String, FieldDefinition> fieldsByName,
+                                                    Map<String, Element> componentsByName) {
+        DefaultMutableTreeNode node = new DefaultMutableTreeNode(new FixDictionaryNodeData.Builder()
+                .withDisplayName(title)
+                .withType(FixDictionaryNodeData.NodeType.SECTION)
+                .withSource(sourceLabel)
+                .build());
+        addMembers(node, element, fieldsByName, componentsByName);
+        return node;
+    }
+
+    private void addMembers(DefaultMutableTreeNode parent, Element container,
+                            Map<String, FieldDefinition> fieldsByName, Map<String, Element> componentsByName) {
+        NodeList childNodes = container.getChildNodes();
+        for (int i = 0; i < childNodes.getLength(); i++) {
+            Node node = childNodes.item(i);
+            if (!(node instanceof Element element)) {
+                continue;
+            }
+            switch (element.getTagName()) {
+                case "field":
+                    parent.add(createFieldNode(element, fieldsByName));
+                    break;
+                case "component":
+                    parent.add(createComponentNode(element, fieldsByName, componentsByName));
+                    break;
+                case "group":
+                    parent.add(createGroupNode(element, fieldsByName, componentsByName));
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    private DefaultMutableTreeNode createFieldNode(Element element, Map<String, FieldDefinition> fieldsByName) {
+        String name = element.getAttribute("name");
+        boolean required = "Y".equalsIgnoreCase(element.getAttribute("required"));
+        FieldDefinition definition = fieldsByName.getOrDefault(name, new FieldDefinition());
+        String display = definition.number != null && !definition.number.isEmpty()
+                ? name + " (" + definition.number + ")"
+                : name;
+        FixDictionaryNodeData data = new FixDictionaryNodeData.Builder()
+                .withType(FixDictionaryNodeData.NodeType.FIELD)
+                .withName(name)
+                .withDisplayName("Field: " + display)
+                .withTagNumber(definition.number)
+                .withFixType(definition.type)
+                .withRequired(required)
+                .withDescription(definition.description)
+                .withEnums(definition.enums)
+                .withSource(sourceLabel)
+                .build();
+        return new DefaultMutableTreeNode(data);
+    }
+
+    private DefaultMutableTreeNode createComponentNode(Element element, Map<String, FieldDefinition> fieldsByName,
+                                                       Map<String, Element> componentsByName) {
+        String name = element.getAttribute("name");
+        boolean required = "Y".equalsIgnoreCase(element.getAttribute("required"));
+        DefaultMutableTreeNode node = new DefaultMutableTreeNode(new FixDictionaryNodeData.Builder()
+                .withType(FixDictionaryNodeData.NodeType.COMPONENT)
+                .withName(name)
+                .withDisplayName("Component: " + name)
+                .withRequired(required)
+                .withSource(sourceLabel)
+                .build());
+        Optional.ofNullable(componentsByName.get(name))
+                .ifPresent(componentElement -> addMembers(node, componentElement, fieldsByName, componentsByName));
+        return node;
+    }
+
+    private DefaultMutableTreeNode createGroupNode(Element element, Map<String, FieldDefinition> fieldsByName,
+                                                   Map<String, Element> componentsByName) {
+        String name = element.getAttribute("name");
+        boolean required = "Y".equalsIgnoreCase(element.getAttribute("required"));
+        FieldDefinition definition = fieldsByName.getOrDefault(name, new FieldDefinition());
+        DefaultMutableTreeNode node = new DefaultMutableTreeNode(new FixDictionaryNodeData.Builder()
+                .withType(FixDictionaryNodeData.NodeType.GROUP)
+                .withName(name)
+                .withDisplayName("Group: " + name)
+                .withTagNumber(definition.number)
+                .withRequired(required)
+                .withSource(sourceLabel)
+                .build());
+        addMembers(node, element, fieldsByName, componentsByName);
+        return node;
+    }
+
+    private Map<String, String> parseEnums(Element element) {
+        Map<String, String> enums = new LinkedHashMap<>();
+        NodeList childNodes = element.getChildNodes();
+        for (int i = 0; i < childNodes.getLength(); i++) {
+            Node node = childNodes.item(i);
+            if (!(node instanceof Element child)) {
+                continue;
+            }
+            if (!"value".equals(child.getTagName())) {
+                continue;
+            }
+            String enumValue = child.getAttribute("enum");
+            String description = child.getAttribute("description");
+            if (enumValue != null && !enumValue.isEmpty()) {
+                enums.put(enumValue, description);
+            }
+        }
+        return enums;
+    }
+
+    private Element firstChild(Element root, String tag) {
+        NodeList nodeList = root.getElementsByTagName(tag);
+        if (nodeList.getLength() == 0) {
+            return null;
+        }
+        Node node = nodeList.item(0);
+        if (node instanceof Element element) {
+            return element;
+        }
+        return null;
+    }
+
+    private static class FieldDefinition {
+        private String name;
+        private String number;
+        private String type;
+        private String description;
+        private Map<String, String> enums = new LinkedHashMap<>();
+    }
+}

--- a/src/main/java/com/rannett/fixplugin/ui/dictionary/FixDictionaryTreePanel.java
+++ b/src/main/java/com/rannett/fixplugin/ui/dictionary/FixDictionaryTreePanel.java
@@ -1,0 +1,180 @@
+package com.rannett.fixplugin.ui.dictionary;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.ui.components.JBList;
+import com.intellij.ui.components.JBScrollPane;
+import com.intellij.ui.treeStructure.Tree;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.BorderFactory;
+import javax.swing.JPanel;
+import javax.swing.JSplitPane;
+import javax.swing.JTree;
+import javax.swing.ListSelectionModel;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeCellRenderer;
+import javax.swing.tree.TreeSelectionModel;
+import java.awt.BorderLayout;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Split-pane panel showing the dictionary tree alongside details of the selected entry.
+ */
+public class FixDictionaryTreePanel extends JPanel {
+
+    private final JPanel detailPanel;
+    private final FixDictionaryTreeModelBuilder modelBuilder;
+
+    /**
+     * Creates a new dictionary tree panel.
+     *
+     * @param sourceLabel label displayed as the dictionary source
+     */
+    public FixDictionaryTreePanel(String sourceLabel) {
+        super(new BorderLayout());
+        this.modelBuilder = new FixDictionaryTreeModelBuilder(sourceLabel);
+        this.detailPanel = new JPanel(new BorderLayout());
+        this.detailPanel.setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
+    }
+
+    /**
+     * Builds the UI using the provided dictionary stream.
+     *
+     * @param inputStream dictionary content
+     * @throws Exception when parsing fails
+     */
+    public void build(@NotNull java.io.InputStream inputStream) throws Exception {
+        DefaultMutableTreeNode rootNode = modelBuilder.buildTree(inputStream);
+        JTree tree = new Tree(rootNode);
+        tree.setRootVisible(true);
+        tree.getSelectionModel().setSelectionMode(TreeSelectionModel.SINGLE_TREE_SELECTION);
+        tree.setCellRenderer(new DictionaryTreeCellRenderer());
+        tree.addTreeSelectionListener(event -> {
+            Object lastPathComponent = event.getPath().getLastPathComponent();
+            if (lastPathComponent instanceof DefaultMutableTreeNode node) {
+                Object userObject = node.getUserObject();
+                if (userObject instanceof FixDictionaryNodeData data) {
+                    renderDetails(data);
+                }
+            }
+        });
+
+        JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
+                new JBScrollPane(tree), new JBScrollPane(detailPanel));
+        splitPane.setResizeWeight(0.35);
+
+        removeAll();
+        add(splitPane, BorderLayout.CENTER);
+        revalidate();
+        tree.setSelectionRow(0);
+    }
+
+    private void renderDetails(FixDictionaryNodeData data) {
+        JPanel content = new JPanel(new GridBagLayout());
+        GridBagConstraints constraints = new GridBagConstraints();
+        constraints.gridx = 0;
+        constraints.gridy = 0;
+        constraints.anchor = GridBagConstraints.NORTHWEST;
+        constraints.insets = new Insets(4, 4, 4, 4);
+
+        addRow(content, constraints, "Name", data.getDisplayName());
+        addRow(content, constraints, "Kind", formatKind(data));
+        addRow(content, constraints, "Tag", nullable(data.getTagNumber()));
+        addRow(content, constraints, "Type", nullable(data.getFixType()));
+        addRow(content, constraints, "MsgType", nullable(data.getMessageType()));
+        addRow(content, constraints, "Required", data.isRequired() ? "Yes" : "No");
+        addRow(content, constraints, "Description", nullable(data.getDescription()));
+        addRow(content, constraints, "Source", nullable(data.getSource()));
+
+        if (!data.getEnums().isEmpty()) {
+            constraints.gridx = 0;
+            constraints.gridy++;
+            constraints.gridwidth = 2;
+            constraints.fill = GridBagConstraints.HORIZONTAL;
+            constraints.anchor = GridBagConstraints.NORTHWEST;
+            JBLabel label = new JBLabel("Enumerations:");
+            label.setFont(label.getFont().deriveFont(label.getFont().getStyle() | java.awt.Font.BOLD));
+            content.add(label, constraints);
+
+            List<String> items = new ArrayList<>();
+            for (Map.Entry<String, String> entry : data.getEnums().entrySet()) {
+                String description = entry.getValue() != null ? entry.getValue() : "";
+                items.add(entry.getKey() + " - " + description);
+            }
+            JBList<String> enumList = new JBList<>(items);
+            enumList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+            constraints.gridy++;
+            constraints.weightx = 1.0;
+            constraints.weighty = 1.0;
+            constraints.fill = GridBagConstraints.BOTH;
+            content.add(new JBScrollPane(enumList), constraints);
+        }
+
+        detailPanel.removeAll();
+        detailPanel.add(content, BorderLayout.NORTH);
+        detailPanel.revalidate();
+        detailPanel.repaint();
+    }
+
+    private void addRow(JPanel panel, GridBagConstraints constraints, String label, String value) {
+        JBLabel fieldLabel = new JBLabel(label + ":");
+        constraints.gridx = 0;
+        constraints.gridwidth = 1;
+        constraints.weightx = 0;
+        constraints.fill = GridBagConstraints.NONE;
+        panel.add(fieldLabel, constraints);
+
+        JBLabel valueLabel = new JBLabel(value);
+        constraints.gridx = 1;
+        constraints.weightx = 1.0;
+        constraints.fill = GridBagConstraints.HORIZONTAL;
+        panel.add(valueLabel, constraints);
+        constraints.gridy++;
+    }
+
+    private String formatKind(FixDictionaryNodeData data) {
+        String base = data.getType().name().toLowerCase();
+        return base.substring(0, 1).toUpperCase() + base.substring(1);
+    }
+
+    private String nullable(String value) {
+        if (value == null || value.isEmpty()) {
+            return "—";
+        }
+        return value;
+    }
+
+    private static class DictionaryTreeCellRenderer extends DefaultTreeCellRenderer {
+        @Override
+        public java.awt.Component getTreeCellRendererComponent(JTree tree, Object value, boolean sel, boolean expanded,
+                                                               boolean leaf, int row, boolean hasFocus) {
+            java.awt.Component component = super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, hasFocus);
+            if (!(value instanceof DefaultMutableTreeNode node)) {
+                return component;
+            }
+            Object userObject = node.getUserObject();
+            if (userObject instanceof FixDictionaryNodeData data) {
+                setIcon(resolveIcon(data));
+                setText(Objects.requireNonNullElse(data.getDisplayName(), ""));
+            }
+            return component;
+        }
+
+        private javax.swing.Icon resolveIcon(FixDictionaryNodeData data) {
+            return switch (data.getType()) {
+                case MESSAGE -> AllIcons.Nodes.Class;
+                case COMPONENT -> AllIcons.Nodes.Method;
+                case GROUP -> AllIcons.Nodes.Folder;
+                case FIELD -> AllIcons.Nodes.Property;
+                default -> AllIcons.Nodes.Package;
+            };
+        }
+    }
+}

--- a/src/main/java/com/rannett/fixplugin/ui/dictionary/OpenAsFixDictionaryAction.java
+++ b/src/main/java/com/rannett/fixplugin/ui/dictionary/OpenAsFixDictionaryAction.java
@@ -1,0 +1,45 @@
+package com.rannett.fixplugin.ui.dictionary;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Action that forces a file to open using the FIX dictionary viewer.
+ */
+public class OpenAsFixDictionaryAction extends AnAction implements DumbAware {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent event) {
+        Project project = event.getProject();
+        if (project == null) {
+            return;
+        }
+        VirtualFile file = event.getData(CommonDataKeys.VIRTUAL_FILE);
+        if (file == null) {
+            return;
+        }
+        file.putUserData(FixDictionaryDetector.FORCE_DICTIONARY_VIEWER, true);
+        FileEditorManager manager = FileEditorManager.getInstance(project);
+        manager.closeFile(file);
+        manager.openFile(file, true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void update(@NotNull AnActionEvent event) {
+        VirtualFile file = event.getData(CommonDataKeys.VIRTUAL_FILE);
+        boolean enabled = file != null && "xml".equalsIgnoreCase(file.getExtension());
+        event.getPresentation().setEnabledAndVisible(enabled);
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -41,6 +41,7 @@
                                     implementationClass="com.rannett.fixplugin.FixDocumentationProvider"/>
 
         <fileEditorProvider implementation="com.rannett.fixplugin.ui.FixDualViewEditorProvider"/>
+        <fileEditorProvider implementation="com.rannett.fixplugin.ui.dictionary.FixDictionaryFileEditorProvider"/>
 
         <multiHostInjector
                 implementation="com.rannett.fixplugin.injection.FixStringLanguageInjector"/>
@@ -66,6 +67,12 @@
                 text="FIX Field Lookup"
                 description="Lookup FIX field information">
             <add-to-group group-id="ToolsMenu" anchor="last"/>
+        </action>
+        <action id="OpenAsFixDictionary"
+                class="com.rannett.fixplugin.ui.dictionary.OpenAsFixDictionaryAction"
+                text="Open as FIX Dictionary"
+                description="Open the selected XML as a structured FIX dictionary">
+            <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
         </action>
     </actions>
 </idea-plugin>

--- a/src/test/java/com/rannett/fixplugin/ui/dictionary/FixDictionaryDetectorTest.java
+++ b/src/test/java/com/rannett/fixplugin/ui/dictionary/FixDictionaryDetectorTest.java
@@ -1,0 +1,38 @@
+package com.rannett.fixplugin.ui.dictionary;
+
+import com.intellij.testFramework.LightVirtualFile;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FixDictionaryDetectorTest {
+
+    @Test
+    /**
+     * Verifies detection succeeds for dictionaries with a FIX root element.
+     */
+    public void detectsFixDictionaryFromContent() {
+        LightVirtualFile file = new LightVirtualFile("FIX.4.4.xml", "<fix><messages></messages></fix>");
+        assertTrue(FixDictionaryDetector.isLikelyFixDictionary(file));
+    }
+
+    @Test
+    /**
+     * Ensures non-dictionary XML files are ignored.
+     */
+    public void rejectsPlainXmlFiles() {
+        LightVirtualFile file = new LightVirtualFile("notes.xml", "<notes><note>hi</note></notes>");
+        assertFalse(FixDictionaryDetector.isLikelyFixDictionary(file));
+    }
+
+    @Test
+    /**
+     * Confirms the manual override flag always enables the viewer.
+     */
+    public void respectsForceFlag() {
+        LightVirtualFile file = new LightVirtualFile("readme.txt", "irrelevant");
+        file.putUserData(FixDictionaryDetector.FORCE_DICTIONARY_VIEWER, true);
+        assertTrue(FixDictionaryDetector.isLikelyFixDictionary(file));
+    }
+}


### PR DESCRIPTION
## Summary
- add a tree-based file editor for FIX dictionaries with synchronized detail panel
- provide detection utilities and an action to force opening XML as a FIX dictionary
- update plugin metadata, documentation, and add detection unit tests

## Testing
- ./gradlew test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926f7131628832c8195d0b7f53c05af)