### PR TITLE
Refactor parsing/timeline, add tests, and improve dictionary fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Replace the dictionary mapping edit dialog with an IntelliJ DialogWrapper implementation to avoid thread context errors
   when updating dictionaries from the settings panel.
 - Ensure selecting a new default dictionary in settings clears the previous default indicator for that FIX version.
+- Fall back to the built-in FIXT.1.1 dictionary when custom dictionaries fail to load so message views remain available.
 
 ## [0.0.1]
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ fields for different messages will be shown in the same row, making comparison e
 - **Dictionary selector** lists bundled and custom dictionaries per FIX version so you can switch parsing dynamically from the viewers.
 - **Dictionary Indicator** shows whether each FIX version uses the default or a modified dictionary directly in the viewers and lets you mark defaults per FIX version.
 - **Default handoff in settings** immediately clears the previous default when you mark another dictionary as preferred for a FIX version, so the table always reflects the active default.
+- **Resilient dictionary fallback** keeps message viewers usable even when custom dictionaries fail to load.
 - **Side-by-side diff viewer** for comparing two messages
 - **Language injection** for FIX messages embedded in code strings
 - **FpML Detection** for XML embedded in tags 351 and 213

--- a/src/main/java/com/rannett/fixplugin/ui/FixMessageFieldParser.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixMessageFieldParser.java
@@ -1,0 +1,90 @@
+package com.rannett.fixplugin.ui;
+
+import java.util.ArrayList;
+import java.util.List;
+import quickfix.field.EncodedSecurityDesc;
+import quickfix.field.EncodedSecurityDescLen;
+import quickfix.field.XmlData;
+import quickfix.field.XmlDataLen;
+
+final class FixMessageFieldParser {
+
+    record TagValue(String tag, String value) {
+    }
+
+    List<TagValue> parseMessage(String message) {
+        List<TagValue> result = new ArrayList<>();
+        int index = 0;
+        int expectedLength = -1;
+        String dataTag = null;
+
+        while (index < message.length()) {
+            int eq = message.indexOf('=', index);
+            if (eq == -1) {
+                break;
+            }
+
+            String tag = message.substring(index, eq);
+            index = eq + 1;
+
+            if (dataTag != null && tag.equals(dataTag) && expectedLength >= 0) {
+                int end = Math.min(index + expectedLength, message.length());
+                String value = message.substring(index, end);
+                result.add(new TagValue(tag, value));
+
+                index = end;
+                while (index < message.length() && Character.isWhitespace(message.charAt(index))) {
+                    index++;
+                }
+                if (index < message.length() && (message.charAt(index) == '|' || message.charAt(index) == '\u0001')) {
+                    index++;
+                }
+
+                dataTag = null;
+                expectedLength = -1;
+                continue;
+            }
+
+            int delimPos = findDelimiter(message, index);
+            String value = message.substring(index, delimPos);
+            result.add(new TagValue(tag, value));
+            index = delimPos + 1;
+
+            if (String.valueOf(XmlDataLen.FIELD).equals(tag)) {
+                dataTag = parseLength(value, XmlData.FIELD);
+                expectedLength = dataTag != null ? Integer.parseInt(value) : -1;
+            } else if (String.valueOf(EncodedSecurityDescLen.FIELD).equals(tag)) {
+                dataTag = parseLength(value, EncodedSecurityDesc.FIELD);
+                expectedLength = dataTag != null ? Integer.parseInt(value) : -1;
+            }
+        }
+
+        return result;
+    }
+
+    private static String parseLength(String value, int field) {
+        try {
+            Integer.parseInt(value);
+            return String.valueOf(field);
+        } catch (NumberFormatException ignore) {
+            return null;
+        }
+    }
+
+    private static int findDelimiter(String message, int start) {
+        int pipe = message.indexOf('|', start);
+        int soh = message.indexOf('\u0001', start);
+        int end;
+        if (pipe == -1) {
+            end = soh;
+        } else if (soh == -1) {
+            end = pipe;
+        } else {
+            end = Math.min(pipe, soh);
+        }
+        if (end == -1) {
+            end = message.length();
+        }
+        return end;
+    }
+}

--- a/src/main/java/com/rannett/fixplugin/ui/FixTimelineMessageNode.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixTimelineMessageNode.java
@@ -1,0 +1,20 @@
+package com.rannett.fixplugin.ui;
+
+import javax.swing.tree.DefaultMutableTreeNode;
+
+final class FixTimelineMessageNode extends DefaultMutableTreeNode {
+    final int index;
+    final String time;
+    final String direction;
+    final String msgTypeCode;
+    final String msgTypeDisplay;
+
+    FixTimelineMessageNode(int index, String time, String direction, String msgTypeCode, String msgTypeDisplay, String summary) {
+        super(summary);
+        this.index = index;
+        this.time = time;
+        this.direction = direction;
+        this.msgTypeCode = msgTypeCode;
+        this.msgTypeDisplay = msgTypeDisplay;
+    }
+}

--- a/src/main/java/com/rannett/fixplugin/ui/FixTimelineNodeBuilder.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixTimelineNodeBuilder.java
@@ -1,0 +1,140 @@
+package com.rannett.fixplugin.ui;
+
+import com.rannett.fixplugin.settings.FixViewerSettingsState.DictionaryEntry;
+import com.rannett.fixplugin.util.FixMessageParser;
+
+import javax.swing.tree.DefaultMutableTreeNode;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import quickfix.DataDictionary;
+import quickfix.Field;
+import quickfix.FieldMap;
+import quickfix.Group;
+import quickfix.Message;
+
+final class FixTimelineNodeBuilder {
+    private final Map<String, String> localPartyBySession = new HashMap<>();
+
+    void resetSessionParties() {
+        localPartyBySession.clear();
+    }
+
+    FixTimelineMessageNode buildNode(String msg, int index) {
+        String begin = extractBeginString(msg);
+        try {
+            DataDictionary dd = FixMessageParser.loadDataDictionary(begin, (DictionaryEntry) null);
+            Message parsed = FixMessageParser.parse(msg, dd);
+
+            String time = parsed.getHeader().isSetField(52) ? parsed.getHeader().getString(52) : "";
+            String typeCode = parsed.getHeader().isSetField(35) ? parsed.getHeader().getString(35) : "";
+            String typeName = buildTypeName(dd, typeCode);
+            String sender = parsed.getHeader().isSetField(49) ? parsed.getHeader().getString(49) : "";
+            String target = parsed.getHeader().isSetField(56) ? parsed.getHeader().getString(56) : "";
+            String direction = determineDirection(sender, target);
+            String summary = FixMessageParser.buildMessageLabel(parsed, dd);
+
+            FixTimelineMessageNode node = new FixTimelineMessageNode(index, time, direction, typeCode, typeName, summary);
+            DefaultMutableTreeNode headerNode = new DefaultMutableTreeNode("Header");
+            buildNodes(parsed.getHeader(), headerNode, dd);
+            node.add(headerNode);
+
+            DefaultMutableTreeNode bodyNode = new DefaultMutableTreeNode("Body");
+            buildNodes(parsed, bodyNode, dd);
+            node.add(bodyNode);
+
+            DefaultMutableTreeNode trailerNode = new DefaultMutableTreeNode("Trailer");
+            buildNodes(parsed.getTrailer(), trailerNode, dd);
+            node.add(trailerNode);
+            return node;
+        } catch (Exception e) {
+            FixTimelineMessageNode node = new FixTimelineMessageNode(index, "", "→", "", "", msg);
+            node.add(new DefaultMutableTreeNode("Parse error: " + e.getMessage()));
+            return node;
+        }
+    }
+
+    private static String buildTypeName(DataDictionary dd, String typeCode) {
+        if (typeCode == null || typeCode.isEmpty()) {
+            return "";
+        }
+        String name = dd.getValueName(35, typeCode);
+        if (name != null && !name.isEmpty()) {
+            return typeCode + " (" + name.toUpperCase() + ")";
+        }
+        return typeCode;
+    }
+
+    private static String extractBeginString(String msg) {
+        int start = msg.indexOf("8=");
+        if (start >= 0) {
+            int pipe = msg.indexOf('|', start);
+            int soh = msg.indexOf('\u0001', start);
+            int end = pipe >= 0 && (soh < 0 || pipe < soh) ? pipe : soh;
+            if (end > start) {
+                return msg.substring(start + 2, end);
+            }
+        }
+        return "FIX.4.4";
+    }
+
+    private String determineDirection(String sender, String target) {
+        if (sender.isEmpty() || target.isEmpty()) {
+            return "→";
+        }
+        String key = sessionKey(sender, target);
+        String local = localPartyBySession.get(key);
+        if (local == null) {
+            localPartyBySession.put(key, sender);
+            local = sender;
+        }
+        if (sender.equals(local)) {
+            return "→";
+        }
+        return "←";
+    }
+
+    private static String sessionKey(String a, String b) {
+        if (a.compareTo(b) < 0) {
+            return a + "|" + b;
+        }
+        return b + "|" + a;
+    }
+
+    private void buildNodes(FieldMap map, DefaultMutableTreeNode parent, DataDictionary dd) {
+        java.util.Iterator<Field<?>> fieldIt = map.iterator();
+        while (fieldIt.hasNext()) {
+            Field<?> field = fieldIt.next();
+            int tag = field.getTag();
+            String name = dd.getFieldName(tag);
+            String value = String.valueOf(field.getObject());
+            String enumName = dd.getValueName(tag, value);
+
+            StringBuilder label = new StringBuilder();
+            label.append(tag).append("=").append(value);
+            if (name != null) {
+                label.append(" (").append(name);
+                if (enumName != null) {
+                    label.append("=").append(enumName);
+                }
+                label.append(")");
+            }
+            parent.add(new DefaultMutableTreeNode(label.toString()));
+        }
+
+        java.util.Iterator<Integer> groupKeys = map.groupKeyIterator();
+        while (groupKeys.hasNext()) {
+            int groupTag = groupKeys.next();
+            List<Group> groups = map.getGroups(groupTag);
+            String groupName = dd.getFieldName(groupTag);
+            int idx = 1;
+            for (Group g : groups) {
+                String title = groupName != null ? groupName : String.valueOf(groupTag);
+                DefaultMutableTreeNode groupNode = new DefaultMutableTreeNode(title + " [" + idx++ + "]");
+                buildNodes(g, groupNode, dd);
+                parent.add(groupNode);
+            }
+        }
+    }
+}

--- a/src/main/java/com/rannett/fixplugin/ui/FixTransposedTableModel.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixTransposedTableModel.java
@@ -8,18 +8,12 @@ import com.rannett.fixplugin.settings.FixViewerSettingsState.DictionaryEntry;
 import javax.swing.SwingUtilities;
 import javax.swing.table.AbstractTableModel;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-import quickfix.field.EncodedSecurityDesc;
-import quickfix.field.EncodedSecurityDescLen;
-import quickfix.field.XmlData;
-import quickfix.field.XmlDataLen;
 
 public class FixTransposedTableModel extends AbstractTableModel {
     private List<String> columnHeaders;
@@ -30,7 +24,26 @@ public class FixTransposedTableModel extends AbstractTableModel {
     private final DocumentUpdater documentUpdater;
     private final Project project;
 
-    private record TagValue(String tag, String value) {
+    private static final FixMessageFieldParser FIELD_PARSER = new FixMessageFieldParser();
+
+    private record RowKey(String tag, int occurrence) {
+        static RowKey fromRowId(String rowId) {
+            int hashIndex = rowId.indexOf('#');
+            if (hashIndex < 0) {
+                return new RowKey(rowId, 1);
+            }
+            String tag = rowId.substring(0, hashIndex);
+            int occurrence = Integer.parseInt(rowId.substring(hashIndex + 1));
+            return new RowKey(tag, occurrence);
+        }
+
+        static RowKey fromTagOccurrence(String tag, int occurrence) {
+            return new RowKey(tag, occurrence);
+        }
+
+        String toRowId() {
+            return tag + "#" + occurrence;
+        }
     }
 
     public FixTransposedTableModel(List<String> fixMessages, DocumentUpdater updater, Project project) {
@@ -58,7 +71,7 @@ public class FixTransposedTableModel extends AbstractTableModel {
         String version = detectFixVersion(fixMessages.isEmpty() ? "" : fixMessages.get(0));
         fixVersion = version != null ? version : "FIXT.1.1";
 
-        List<List<TagValue>> parsed = new ArrayList<>();
+        List<List<FixMessageFieldParser.TagValue>> parsed = new ArrayList<>();
         // Maintain the order of tag occurrences as they first appear across all messages
         tagOrder = new ArrayList<>();
         Set<String> seenRows = new LinkedHashSet<>();
@@ -74,13 +87,13 @@ public class FixTransposedTableModel extends AbstractTableModel {
             String msgId = "Message " + i++;
             columnHeaders.add(msgId);
 
-            List<TagValue> pairs = parseFixMessage(message);
+            List<FixMessageFieldParser.TagValue> pairs = FIELD_PARSER.parseMessage(message);
             parsed.add(pairs);
 
             Map<String, Integer> counts = new LinkedHashMap<>();
-            for (TagValue tv : pairs) {
+            for (FixMessageFieldParser.TagValue tv : pairs) {
                 int occ = counts.merge(tv.tag, 1, Integer::sum);
-                String rowId = tv.tag + "#" + occ;
+                String rowId = RowKey.fromTagOccurrence(tv.tag, occ).toRowId();
                 if (seenRows.add(rowId)) {
                     tagOrder.add(rowId);
                     transposed.put(rowId, new LinkedHashMap<>());
@@ -91,9 +104,9 @@ public class FixTransposedTableModel extends AbstractTableModel {
         for (int idx = 0; idx < parsed.size(); idx++) {
             String msgId = columnHeaders.get(idx);
             Map<String, Integer> counts = new LinkedHashMap<>();
-            for (TagValue tv : parsed.get(idx)) {
+            for (FixMessageFieldParser.TagValue tv : parsed.get(idx)) {
                 counts.merge(tv.tag, 1, Integer::sum);
-                String rowId = tv.tag + "#" + counts.get(tv.tag);
+                String rowId = RowKey.fromTagOccurrence(tv.tag, counts.get(tv.tag)).toRowId();
                 transposed.get(rowId).put(msgId, tv.value);
             }
         }
@@ -101,115 +114,6 @@ public class FixTransposedTableModel extends AbstractTableModel {
 
     private String detectFixVersion(String message) {
         return com.rannett.fixplugin.util.FixUtils.extractFixVersion(message).orElse(null);
-    }
-
-    /**
-     * Parse a FIX message into tag/value pairs while preserving embedded data.
-     * <p>
-     * Certain FIX fields such as {@code XmlData.FIELD} and
-     * {@code EncodedSecurityDesc.FIELD} may contain XML that itself includes
-     * delimiter characters. These fields are preceded by a length tag
-     * ({@code XmlDataLen.FIELD} or {@code EncodedSecurityDescLen.FIELD})
-     * specifying how many characters to read. This method keeps
-     * track of these lengths so that the embedded XML is extracted correctly.
-     *
-     * @param msg raw FIX message using either {@code |} or SOH as delimiters
-     * @return ordered list of tag/value pairs from the message
-     */
-    private List<TagValue> parseFixMessage(String msg) {
-        // Parsed output
-        List<TagValue> result = new ArrayList<>();
-
-        // Cursor into the raw message string
-        int index = 0;
-
-        // When a length field (XmlDataLen or EncodedSecurityDescLen) is encountered
-        // the following tag will contain raw data of this length. 'expectedLength'
-        // holds the number of characters to read and 'dataTag' stores the tag number
-        // that should receive that data.
-        int expectedLength = -1;
-        String dataTag = null;
-
-        // Iterate over the message: tag=value<delimiter>
-        while (index < msg.length()) {
-            // Find the '=' separating the tag from the value
-            int eq = msg.indexOf('=', index);
-            if (eq == -1) {
-                break; // malformed message
-            }
-
-            String tag = msg.substring(index, eq);
-            index = eq + 1;
-
-            // If we previously saw a length tag, read the exact number of
-            // characters for the current value regardless of delimiters.
-            if (dataTag != null && tag.equals(dataTag) && expectedLength >= 0) {
-                int end = Math.min(index + expectedLength, msg.length());
-                String value = msg.substring(index, end);
-                result.add(new TagValue(tag, value));
-
-                // Move the cursor past the consumed data and optional delimiter
-                index = end;
-                // Some producers do not include trailing line breaks in the
-                // length field. Skip over any whitespace before the delimiter
-                while (index < msg.length() && Character.isWhitespace(msg.charAt(index))) {
-                    index++;
-                }
-                if (index < msg.length() && (msg.charAt(index) == '|' || msg.charAt(index) == '\u0001')) {
-                    index++;
-                }
-
-                // Reset special parsing state for the next iteration
-                dataTag = null;
-                expectedLength = -1;
-                continue;
-            }
-
-            // Read a value terminated by the next delimiter character
-            int delimPos = findDelimiter(msg, index);
-            String value = msg.substring(index, delimPos);
-            result.add(new TagValue(tag, value));
-            index = delimPos + 1; // skip the delimiter
-
-            // Check for length fields that signal the next tag contains raw data
-            if (String.valueOf(XmlDataLen.FIELD).equals(tag)) { // XMLDataLen
-                try {
-                    expectedLength = Integer.parseInt(value);
-                    dataTag = String.valueOf(XmlData.FIELD); // XMLData follows
-                } catch (NumberFormatException ignore) {
-                    // Invalid length values are treated as normal fields
-                    expectedLength = -1;
-                    dataTag = null;
-                }
-            } else if (String.valueOf(EncodedSecurityDescLen.FIELD).equals(tag)) { // EncodedSecurityDescLen
-                try {
-                    expectedLength = Integer.parseInt(value);
-                    dataTag = String.valueOf(EncodedSecurityDesc.FIELD); // EncodedSecurityDesc follows
-                } catch (NumberFormatException ignore) {
-                    expectedLength = -1;
-                    dataTag = null;
-                }
-            }
-        }
-
-        return result;
-    }
-
-    private int findDelimiter(String msg, int start) {
-        int pipe = msg.indexOf('|', start);
-        int soh = msg.indexOf('\u0001', start);
-        int end = -1;
-        if (pipe == -1) {
-            end = soh;
-        } else if (soh == -1) {
-            end = pipe;
-        } else {
-            end = Math.min(pipe, soh);
-        }
-        if (end == -1) {
-            end = msg.length();
-        }
-        return end;
     }
 
     @Override
@@ -230,7 +134,7 @@ public class FixTransposedTableModel extends AbstractTableModel {
     @Override
     public Object getValueAt(int rowIndex, int columnIndex) {
         String rowId = tagOrder.get(rowIndex);
-        String tag = rowId.contains("#") ? rowId.substring(0, rowId.indexOf('#')) : rowId;
+        String tag = RowKey.fromRowId(rowId).tag();
         if (columnIndex == 0) {
             return tag;
         }
@@ -252,16 +156,11 @@ public class FixTransposedTableModel extends AbstractTableModel {
     @Override
     public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
         String rowId = tagOrder.get(rowIndex);
-        String tag = rowId.contains("#") ? rowId.substring(0, rowId.indexOf('#')) : rowId;
-        int occurrence = 1;
-        int hashIndex = rowId.indexOf('#');
-        if (hashIndex >= 0) {
-            occurrence = Integer.parseInt(rowId.substring(hashIndex + 1));
-        }
+        RowKey key = RowKey.fromRowId(rowId);
         String msgId = columnHeaders.get(columnIndex - 2);
         String newValue = aValue.toString();
         transposed.get(rowId).put(msgId, newValue);
-        documentUpdater.updateTagValueInMessage(msgId, tag, occurrence, newValue);
+        documentUpdater.updateTagValueInMessage(msgId, key.tag(), key.occurrence(), newValue);
         fireTableCellUpdated(rowIndex, columnIndex);
     }
 
@@ -281,7 +180,7 @@ public class FixTransposedTableModel extends AbstractTableModel {
 
     public String getTagAtRow(int rowIndex) {
         String rowId = tagOrder.get(rowIndex);
-        return rowId.contains("#") ? rowId.substring(0, rowId.indexOf('#')) : rowId;
+        return RowKey.fromRowId(rowId).tag();
     }
 
     public String getMessageIdForColumn(int columnIndex) {

--- a/src/test/java/com/rannett/fixplugin/ui/FixMessageFieldParserTest.java
+++ b/src/test/java/com/rannett/fixplugin/ui/FixMessageFieldParserTest.java
@@ -1,0 +1,24 @@
+package com.rannett.fixplugin.ui;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class FixMessageFieldParserTest {
+
+    @Test
+    public void testLengthDelimitedFieldPreservesDelimiterCharacters() {
+        String message = "8=FIX.4.4|212=5|213=a|b|c|10=000|";
+        FixMessageFieldParser parser = new FixMessageFieldParser();
+
+        List<FixMessageFieldParser.TagValue> values = parser.parseMessage(message);
+
+        FixMessageFieldParser.TagValue xmlData = values.stream()
+                .filter(tv -> "213".equals(tv.tag()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("a|b|c", xmlData.value());
+    }
+}

--- a/src/test/java/com/rannett/fixplugin/ui/FixTimelineNodeBuilderTest.java
+++ b/src/test/java/com/rannett/fixplugin/ui/FixTimelineNodeBuilderTest.java
@@ -1,0 +1,51 @@
+package com.rannett.fixplugin.ui;
+
+import org.junit.Test;
+
+import javax.swing.tree.DefaultMutableTreeNode;
+import java.util.Enumeration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class FixTimelineNodeBuilderTest {
+
+    @Test
+    public void testParseErrorNodeAddsErrorChild() {
+        FixTimelineNodeBuilder builder = new FixTimelineNodeBuilder();
+
+        FixTimelineMessageNode node = builder.buildNode("not-a-fix-message", 1);
+
+        assertEquals("not-a-fix-message", node.getUserObject());
+        assertEquals(1, node.getChildCount());
+        DefaultMutableTreeNode errorNode = (DefaultMutableTreeNode) node.getChildAt(0);
+        assertTrue(errorNode.getUserObject().toString().startsWith("Parse error:"));
+    }
+
+    @Test
+    public void testGroupFieldsAppearUnderBodyNode() {
+        FixTimelineNodeBuilder builder = new FixTimelineNodeBuilder();
+        String message = "8=FIX.4.4|9=75|35=D|49=SENDER|56=TARGET|34=1|52=20240101-00:00:00.000|" +
+                "453=1|448=PARTY|447=D|452=1|10=000|";
+
+        FixTimelineMessageNode node = builder.buildNode(message, 1);
+
+        DefaultMutableTreeNode bodyNode = (DefaultMutableTreeNode) node.getChildAt(1);
+        boolean foundGroup = hasChildWithPrefix(bodyNode, "NoPartyIDs [1]");
+        assertTrue(foundGroup);
+    }
+
+    private static boolean hasChildWithPrefix(DefaultMutableTreeNode parent, String prefix) {
+        Enumeration<?> children = parent.children();
+        while (children.hasMoreElements()) {
+            Object child = children.nextElement();
+            if (child instanceof DefaultMutableTreeNode) {
+                String label = ((DefaultMutableTreeNode) child).getUserObject().toString();
+                if (label.startsWith(prefix)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/src/test/java/com/rannett/fixplugin/ui/FixTransposedTableModelTest.java
+++ b/src/test/java/com/rannett/fixplugin/ui/FixTransposedTableModelTest.java
@@ -3,6 +3,7 @@ package com.rannett.fixplugin.ui;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.*;
 
@@ -15,5 +16,29 @@ public class FixTransposedTableModelTest {
         assertEquals("Message 1", model.getMessageIdForColumn(2));
         assertNull(model.getMessageIdForColumn(1));
         assertNull(model.getMessageIdForColumn(3));
+    }
+
+    @Test
+    public void testMultipleTagOccurrencesCreateDistinctRows() {
+        List<String> messages = List.of("8=FIX.4.4|58=one|58=two|10=000|");
+        FixTransposedTableModel model = new FixTransposedTableModel(messages, (id, tag, occ, value) -> { }, null);
+
+        assertEquals(2, model.getRowCount());
+        assertEquals("58", model.getValueAt(0, 0));
+        assertEquals("one", model.getValueAt(0, 2));
+        assertEquals("58", model.getValueAt(1, 0));
+        assertEquals("two", model.getValueAt(1, 2));
+    }
+
+    @Test
+    public void testSetValueAtUsesOccurrence() {
+        List<String> messages = List.of("8=FIX.4.4|58=one|58=two|10=000|");
+        AtomicReference<String> updated = new AtomicReference<>();
+        FixTransposedTableModel model = new FixTransposedTableModel(messages,
+                (id, tag, occ, value) -> updated.set(tag + ":" + occ + ":" + value), null);
+
+        model.setValueAt("updated", 1, 2);
+
+        assertEquals("58:2:updated", updated.get());
     }
 }

--- a/src/test/java/com/rannett/fixplugin/util/FixMessageParserDictionaryTest.java
+++ b/src/test/java/com/rannett/fixplugin/util/FixMessageParserDictionaryTest.java
@@ -1,0 +1,36 @@
+package com.rannett.fixplugin.util;
+
+import com.rannett.fixplugin.settings.FixViewerSettingsState.DictionaryEntry;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertNotNull;
+
+public class FixMessageParserDictionaryTest {
+
+    @Test
+    public void testLoadCustomDictionaryPath() throws IOException {
+        Path tempFile = Files.createTempFile("fix-dict", ".xml");
+        tempFile.toFile().deleteOnExit();
+
+        try (InputStream stream = FixMessageParser.class.getResourceAsStream("/dictionaries/FIX.4.4.xml")) {
+            assertNotNull(stream);
+            Files.copy(stream, tempFile, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        }
+
+        DictionaryEntry entry = new DictionaryEntry("FIX.4.4", tempFile.toString(), false, true);
+
+        assertNotNull(FixMessageParser.loadDataDictionary("FIX.4.4", entry));
+    }
+
+    @Test
+    public void testLoadDictionaryFallsBackWhenCustomPathFails() {
+        DictionaryEntry entry = new DictionaryEntry("FIX.4.4", "missing-dictionary.xml", false, true);
+
+        assertNotNull(FixMessageParser.loadDataDictionary("FIX.4.4", entry));
+    }
+}


### PR DESCRIPTION
### Motivation

- Extract the FIX field parsing and occurrence tracking to make transposed table logic simpler and handle length-delimited data fields correctly.
- Move timeline node creation into a dedicated builder and node type to separate parsing/UI concerns and make direction detection consistent across messages.
- Make dictionary loading more resilient so viewers remain usable when custom dictionaries fail to load.
- Update docs and changelog to reflect the new fallback behaviour and added features.

### Description

- Introduced `FixMessageFieldParser` to parse tag/value pairs while preserving length-delimited data fields and used it from `FixTransposedTableModel` (including a `RowKey` helper for occurrence-aware row ids).
- Extracted timeline node creation into `FixTimelineNodeBuilder` and a dedicated `FixTimelineMessageNode`, and updated `FixCommTimelinePanel` to use the builder.
- Refactored `FixMessageParser.loadDataDictionary` into smaller helpers (`loadDictionaryVersion`, `loadCustomDictionary`, `loadResourceDictionary`, `loadFallbackDictionary`) and added a fall-back to the built-in `FIXT.1.1` dictionary when custom/resource loading fails.
- Added unit tests and docs updates: new tests `FixMessageFieldParserTest`, `FixTimelineNodeBuilderTest`, `FixMessageParserDictionaryTest`, updated `FixTransposedTableModelTest`, plus `README.md` and `CHANGELOG.md` entries.

### Testing

- New unit tests were added: `FixMessageFieldParserTest`, `FixTimelineNodeBuilderTest`, `FixMessageParserDictionaryTest`, and enhancements to `FixTransposedTableModelTest`.
- I began an automated test run with `./gradlew test`; the test run was started but was interrupted before completion (SIGINT), so the full test-suite result is not verified end-to-end.
- The test run produced progress output prior to interruption indicating tests were being exercised, but a successful full run should be re-run to confirm all tests pass.
- Recommend running `./gradlew test` in CI or locally to validate the entire suite after review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962568bab98832cbc75acd1533c1ef6)