### PR TITLE
Add log cleanup button to FIX editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,9 @@
 
 ### Added
 
-- Publish Qodana inspection results to GitHub code scanning with SARIF uploads.
 
 ### Fixed
 
-- Remove the maximum IDE compatibility so the plugin can install on newer IntelliJ versions.
-- Use the configured IntelliJ platform version for plugin verification to avoid missing IDE artifacts.
-- Allow a dedicated plugin verification IDE version so CI can pin to a stable release.
-- Fix plugin verification IDE selection wiring so Gradle can compile the build script.
-- Update the Gradle wrapper so builds run on newer Java runtimes without failing to parse the version.
-- Fallback to Java 17 in the Gradle wrapper when Java 25 is detected to keep builds running.
-- Use the non-deprecated plugin verifier IDE registration to avoid selecting missing IDE artifacts.
-- Fix Qodana CI execution by using full git history and compatible CLI options.
-- Strip non-FIX log prefixes and suffixes in the FIX editor to leave clean messages when logs wrap the payload.
 
 ## [0.0.1]
 
@@ -171,3 +161,28 @@
 - Replace the dictionary mapping edit dialog with an IntelliJ DialogWrapper implementation to avoid thread context errors
   when updating dictionaries from the settings panel.
 - Ensure selecting a new default dictionary in settings clears the previous default indicator for that FIX version.
+
+## [0.0.19]
+
+### Added
+
+- Publish Qodana inspection results to GitHub code scanning with SARIF uploads.
+
+### Fixed
+
+- Remove the maximum IDE compatibility so the plugin can install on newer IntelliJ versions.
+- Use the configured IntelliJ platform version for plugin verification to avoid missing IDE artifacts.
+- Allow a dedicated plugin verification IDE version so CI can pin to a stable release.
+- Fix plugin verification IDE selection wiring so Gradle can compile the build script.
+- Update the Gradle wrapper so builds run on newer Java runtimes without failing to parse the version.
+- Fallback to Java 17 in the Gradle wrapper when Java 25 is detected to keep builds running.
+- Use the non-deprecated plugin verifier IDE registration to avoid selecting missing IDE artifacts.
+- Fix Qodana CI execution by using full git history and compatible CLI options.
+
+## [0.0.20]
+
+### Added
+
+- Strip non-FIX log prefixes and suffixes in the FIX editor to leave clean messages when logs wrap the payload.
+
+### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fallback to Java 17 in the Gradle wrapper when Java 25 is detected to keep builds running.
 - Use the non-deprecated plugin verifier IDE registration to avoid selecting missing IDE artifacts.
 - Fix Qodana CI execution by using full git history and compatible CLI options.
+- Strip non-FIX log prefixes and suffixes in the FIX editor to leave clean messages when logs wrap the payload.
 
 ## [0.0.1]
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ There is also a tree view, to show the message structure, and a communications v
 - **Dictionary selector** lists bundled and custom dictionaries per FIX version so you can switch parsing dynamically from the viewers.
 - **Dictionary Indicator** shows whether each FIX version uses the default or a modified dictionary directly in the viewers and lets you mark defaults per FIX version.
 - **Side-by-side diff viewer** for comparing two messages
+- **Log cleanup button** to strip non-FIX prefixes/suffixes and keep pure FIX messages in the editor
 - **Language injection** for FIX messages embedded in code strings
 - **FpML Detection** for XML embedded in tags 351 and 213
 - **Lexer support** for multi-line FpML blocks

--- a/README.md
+++ b/README.md
@@ -44,9 +44,6 @@ There is also a tree view, to show the message structure, and a communications v
 - **Updated Gradle wrapper** to keep CI builds compatible with newer Java runtimes
 - **Gradle wrapper Java fallback** to keep builds working when newer JDKs are installed
 - **Explicit plugin verifier IDE registration** to keep verification aligned with configured IDE builds
-- **Qodana SARIF uploads** so code inspection results appear in GitHub code scanning
-
-
 
 ---
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 pluginGroup=com.rannett.fix-viewer
 pluginName=Financial Information eXchange Message Viewer
 # SemVer format -> https://semver.org
-pluginVersion=0.0.21
+pluginVersion=0.0.20
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=242
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension

--- a/src/main/java/com/rannett/fixplugin/ui/FixDualViewEditor.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixDualViewEditor.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.JComponent;
 import javax.swing.DefaultComboBoxModel;
+import javax.swing.JButton;
 import javax.swing.JPanel;
 import javax.swing.JTabbedPane;
 import javax.swing.SwingUtilities;
@@ -73,6 +74,10 @@ public class FixDualViewEditor extends UserDataHolderBase implements FileEditor 
         dictionaryPanel.add(new JBLabel("Dictionary:"), BorderLayout.WEST);
         dictionaryPanel.add(dictionarySelector, BorderLayout.CENTER);
         headerPanel.add(dictionaryPanel, BorderLayout.WEST);
+        JButton cleanLogButton = new JButton("Strip Log Text");
+        cleanLogButton.setToolTipText("Remove non-FIX log prefixes/suffixes and keep only FIX messages");
+        cleanLogButton.addActionListener(event -> stripNonFixLogText());
+        headerPanel.add(cleanLogButton, BorderLayout.EAST);
         mainPanel.add(headerPanel, BorderLayout.NORTH);
 
         tabbedPane.addTab("Text View", textEditor.getComponent());
@@ -261,6 +266,13 @@ public class FixDualViewEditor extends UserDataHolderBase implements FileEditor 
                     (Computable<List<String>>) () -> FixMessageParser.splitMessages(document.getText())
             );
             treePanel.updateTree(updatedMessages);
+        });
+    }
+
+    private void stripNonFixLogText() {
+        WriteCommandAction.runWriteCommandAction(project, () -> {
+            String cleanedText = FixMessageParser.extractFixMessagesText(document.getText());
+            document.replaceString(0, document.getTextLength(), cleanedText);
         });
     }
 

--- a/src/main/java/com/rannett/fixplugin/util/FixMessageParser.java
+++ b/src/main/java/com/rannett/fixplugin/util/FixMessageParser.java
@@ -13,6 +13,8 @@ import quickfix.Message;
 
 import java.io.File;
 import java.io.InputStream;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Utility methods for parsing FIX messages with QuickFIX/J.
@@ -251,5 +253,19 @@ public final class FixMessageParser {
 
     private static boolean isFieldDelimiter(char character) {
         return character == '\u0001' || character == '|';
+    }
+
+    /**
+     * Extract only FIX messages from a larger block of text, stripping away log prefixes,
+     * suffixes, and other non-FIX content that may surround messages.
+     *
+     * @param text raw text containing FIX messages and log content
+     * @return a newline-delimited string containing only FIX messages
+     */
+    public static String extractFixMessagesText(@NotNull String text) {
+        List<String> messages = splitMessages(text);
+        return messages.stream()
+                .filter(message -> FixUtils.extractFixVersion(message).isPresent())
+                .collect(Collectors.joining("\n"));
     }
 }


### PR DESCRIPTION
### Motivation
- Logs produced by quickfixj often wrap FIX payloads with timestamp/level prefixes and trailing logging data, making the editor show noisy lines instead of pure FIX messages. 
- Provide a one-click way to strip that surrounding log text so the viewer and downstream parsers operate on clean FIX messages.

### Description
- Add a `Strip Log Text` button to the editor header in `FixDualViewEditor` which invokes a cleanup action that replaces the document contents under a write command. (`src/main/java/com/rannett/fixplugin/ui/FixDualViewEditor.java`).
- Implement `extractFixMessagesText` in `FixMessageParser` to reuse the existing `splitMessages` logic and return a newline-delimited string containing only entries that contain a valid FIX `BeginString`. (`src/main/java/com/rannett/fixplugin/util/FixMessageParser.java`).
- The editor action runs `WriteCommandAction` and writes the cleaned text back into the document to preserve IntelliJ write/threading semantics. (`FixDualViewEditor#stripNonFixLogText`).
- Document the new feature in `README.md` and add an entry to the `Unreleased` section of `CHANGELOG.md` noting the fix. (`README.md`, `CHANGELOG.md`).

### Testing
- No automated tests were executed for this change in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69762414d524832ca3da29deb9c50501)