### PR TITLE
Add QuickFIX session config detection and highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 
+- QuickFIX session config detection with safe content-based heuristics, plus dedicated syntax highlighting.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Use locale-insensitive FIX type matching so validation stays accurate under non-English locales.
 - Avoid returning empty entries when splitting or extracting FIX messages from whitespace-only input.
+- Fix QuickFIX config file detection wiring for the IntelliJ 2024.2 file type detector API.
 
 ## [0.0.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Use locale-insensitive FIX type matching so validation stays accurate under non-English locales.
 - Avoid returning empty entries when splitting or extracting FIX messages from whitespace-only input.
 - Fix QuickFIX config file detection wiring for the IntelliJ 2024.2 file type detector API.
+- Fix QuickFIX config detection imports to compile against the IntelliJ platform ByteSequence API.
 
 ## [0.0.1]
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ There is also a tree view, to show the message structure, and a communications v
 - **Message Hiding** in the transposed view for large message files
 - **Enumerated Values** suggested as items in the table view
 - **Override Dictionaries** with bespoke ones. Standard Quickfix dictionaries are used.
+- **QuickFIX session config detection** with dedicated highlighting, safe content-based recognition for config files, and manual association via *Associate with File Type → QuickFIX Session Config*.
 - **Dictionary selector** lists bundled and custom dictionaries per FIX version so you can switch parsing dynamically from the viewers.
 - **Dictionary Indicator** shows whether each FIX version uses the default or a modified dictionary directly in the viewers and lets you mark defaults per FIX version.
 - **Side-by-side diff viewer** for comparing two messages

--- a/src/main/java/com/rannett/fixplugin/quickfix/QuickFixConfigFileType.java
+++ b/src/main/java/com/rannett/fixplugin/quickfix/QuickFixConfigFileType.java
@@ -1,0 +1,67 @@
+package com.rannett.fixplugin.quickfix;
+
+import com.intellij.openapi.fileTypes.LanguageFileType;
+import com.rannett.fixplugin.FixIcons;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.Icon;
+
+/**
+ * File type for QuickFIX session configuration files.
+ */
+public class QuickFixConfigFileType extends LanguageFileType {
+
+    /**
+     * Singleton instance for the QuickFIX config file type.
+     */
+    public static final QuickFixConfigFileType INSTANCE = new QuickFixConfigFileType();
+
+    private QuickFixConfigFileType() {
+        super(QuickFixConfigLanguage.INSTANCE);
+    }
+
+    /**
+     * Returns the name of the file type.
+     *
+     * @return the file type name.
+     */
+    @NotNull
+    @Override
+    public String getName() {
+        return "QuickFIX Session Config";
+    }
+
+    /**
+     * Returns the description of the file type.
+     *
+     * @return the file type description.
+     */
+    @NotNull
+    @Override
+    public String getDescription() {
+        return "QuickFIX session configuration";
+    }
+
+    /**
+     * Returns the default extension for the file type.
+     *
+     * @return the default extension.
+     */
+    @NotNull
+    @Override
+    public String getDefaultExtension() {
+        return "fix.cfg";
+    }
+
+    /**
+     * Returns the icon for the file type.
+     *
+     * @return the file type icon.
+     */
+    @Nullable
+    @Override
+    public Icon getIcon() {
+        return FixIcons.FILE;
+    }
+}

--- a/src/main/java/com/rannett/fixplugin/quickfix/QuickFixConfigFileTypeDetector.java
+++ b/src/main/java/com/rannett/fixplugin/quickfix/QuickFixConfigFileTypeDetector.java
@@ -2,7 +2,7 @@ package com.rannett.fixplugin.quickfix;
 
 import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.fileTypes.FileTypeRegistry;
-import com.intellij.openapi.util.text.ByteSequence;
+import com.intellij.openapi.util.io.ByteSequence;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/com/rannett/fixplugin/quickfix/QuickFixConfigFileTypeDetector.java
+++ b/src/main/java/com/rannett/fixplugin/quickfix/QuickFixConfigFileTypeDetector.java
@@ -1,0 +1,48 @@
+package com.rannett.fixplugin.quickfix;
+
+import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.openapi.fileTypes.FileTypeDetector;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.regex.Pattern;
+
+/**
+ * Detects QuickFIX session configuration files based on file content.
+ */
+public class QuickFixConfigFileTypeDetector implements FileTypeDetector {
+
+    private static final int MAX_SAMPLE_SIZE = 65536;
+    private static final Pattern SECTION_PATTERN = Pattern.compile("(?m)^\\s*\\[(DEFAULT|SESSION)]\\s*$");
+    private static final Pattern KEY_PATTERN = Pattern.compile(
+            "(?m)^\\s*(BeginString|SenderCompID|TargetCompID|ConnectionType)\\s*="
+    );
+
+    /**
+     * Attempts to detect a QuickFIX session configuration file.
+     *
+     * @param file the file to check.
+     * @param content the file content as bytes.
+     * @param fileContent the file content as text.
+     * @return the QuickFIX config file type if detected; otherwise {@code null}.
+     */
+    @Nullable
+    @Override
+    public FileType detect(@NotNull VirtualFile file, @NotNull byte[] content, @NotNull CharSequence fileContent) {
+        if (!looksLikeQuickFixConfig(fileContent)) {
+            return null;
+        }
+        return QuickFixConfigFileType.INSTANCE;
+    }
+
+    private boolean looksLikeQuickFixConfig(@NotNull CharSequence fileContent) {
+        int length = Math.min(fileContent.length(), MAX_SAMPLE_SIZE);
+        String sample = fileContent.subSequence(0, length).toString();
+        boolean hasSection = SECTION_PATTERN.matcher(sample).find();
+        if (!hasSection) {
+            return false;
+        }
+        return KEY_PATTERN.matcher(sample).find();
+    }
+}

--- a/src/main/java/com/rannett/fixplugin/quickfix/QuickFixConfigLanguage.java
+++ b/src/main/java/com/rannett/fixplugin/quickfix/QuickFixConfigLanguage.java
@@ -1,0 +1,30 @@
+package com.rannett.fixplugin.quickfix;
+
+import com.intellij.lang.Language;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Language definition for QuickFIX session configuration files.
+ */
+public class QuickFixConfigLanguage extends Language {
+
+    /**
+     * Singleton instance for QuickFIX config language.
+     */
+    public static final QuickFixConfigLanguage INSTANCE = new QuickFixConfigLanguage();
+
+    private QuickFixConfigLanguage() {
+        super("QuickFixConfig");
+    }
+
+    /**
+     * Returns the display name for the language.
+     *
+     * @return the language name.
+     */
+    @NotNull
+    @Override
+    public String getDisplayName() {
+        return "QuickFIX Session Config";
+    }
+}

--- a/src/main/java/com/rannett/fixplugin/quickfix/QuickFixConfigLexer.java
+++ b/src/main/java/com/rannett/fixplugin/quickfix/QuickFixConfigLexer.java
@@ -1,0 +1,230 @@
+package com.rannett.fixplugin.quickfix;
+
+import com.intellij.lexer.LexerBase;
+import com.intellij.psi.TokenType;
+import com.intellij.psi.tree.IElementType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Lexer for QuickFIX session configuration files.
+ */
+public class QuickFixConfigLexer extends LexerBase {
+
+    private CharSequence buffer;
+    private int bufferEnd;
+    private int tokenStart;
+    private int tokenEnd;
+    private IElementType tokenType;
+
+    /**
+     * Creates a new lexer instance.
+     */
+    public QuickFixConfigLexer() {
+        this.buffer = "";
+    }
+
+    /**
+     * Initializes the lexer with a new buffer.
+     *
+     * @param buffer the buffer to lex.
+     * @param startOffset the start offset.
+     * @param endOffset the end offset.
+     * @param initialState the initial lexer state.
+     */
+    @Override
+    public void start(@NotNull CharSequence buffer, int startOffset, int endOffset, int initialState) {
+        this.buffer = buffer;
+        this.bufferEnd = endOffset;
+        this.tokenStart = startOffset;
+        this.tokenEnd = startOffset;
+        this.tokenType = null;
+        advance();
+    }
+
+    /**
+     * Returns the current lexer state.
+     *
+     * @return the lexer state.
+     */
+    @Override
+    public int getState() {
+        return 0;
+    }
+
+    /**
+     * Returns the current token type.
+     *
+     * @return the token type.
+     */
+    @Nullable
+    @Override
+    public IElementType getTokenType() {
+        return tokenType;
+    }
+
+    /**
+     * Returns the start offset of the current token.
+     *
+     * @return the start offset.
+     */
+    @Override
+    public int getTokenStart() {
+        return tokenStart;
+    }
+
+    /**
+     * Returns the end offset of the current token.
+     *
+     * @return the end offset.
+     */
+    @Override
+    public int getTokenEnd() {
+        return tokenEnd;
+    }
+
+    /**
+     * Advances to the next token.
+     */
+    @Override
+    public void advance() {
+        tokenStart = tokenEnd;
+        locateToken();
+    }
+
+    /**
+     * Returns the buffer sequence.
+     *
+     * @return the buffer sequence.
+     */
+    @NotNull
+    @Override
+    public CharSequence getBufferSequence() {
+        return buffer;
+    }
+
+    /**
+     * Returns the end offset of the buffer.
+     *
+     * @return the buffer end offset.
+     */
+    @Override
+    public int getBufferEnd() {
+        return bufferEnd;
+    }
+
+    private void locateToken() {
+        if (tokenStart >= bufferEnd) {
+            tokenType = null;
+            return;
+        }
+
+        char currentChar = buffer.charAt(tokenStart);
+        if (Character.isWhitespace(currentChar)) {
+            int offset = tokenStart;
+            while (offset < bufferEnd && Character.isWhitespace(buffer.charAt(offset))) {
+                offset++;
+            }
+            tokenEnd = offset;
+            tokenType = TokenType.WHITE_SPACE;
+            return;
+        }
+
+        int lineStart = findLineStart(tokenStart);
+        int lineEnd = findLineEnd(tokenStart);
+        int firstNonWhitespace = findFirstNonWhitespace(lineStart, lineEnd);
+
+        if (tokenStart < firstNonWhitespace) {
+            tokenEnd = firstNonWhitespace;
+            tokenType = TokenType.WHITE_SPACE;
+            return;
+        }
+
+        if (tokenStart == firstNonWhitespace) {
+            if (isCommentStart(tokenStart, lineEnd)) {
+                tokenEnd = lineEnd;
+                tokenType = QuickFixConfigTokenType.COMMENT;
+                return;
+            }
+
+            if (currentChar == '[') {
+                int closingBracket = indexOf(']', tokenStart + 1, lineEnd);
+                if (closingBracket != -1) {
+                    tokenEnd = closingBracket + 1;
+                    tokenType = QuickFixConfigTokenType.SECTION;
+                    return;
+                }
+            }
+        }
+
+        int equalsIndex = indexOf('=', lineStart, lineEnd);
+        if (equalsIndex != -1) {
+            if (tokenStart < equalsIndex) {
+                tokenEnd = equalsIndex;
+                tokenType = QuickFixConfigTokenType.KEY;
+                return;
+            }
+
+            if (tokenStart == equalsIndex) {
+                tokenEnd = tokenStart + 1;
+                tokenType = QuickFixConfigTokenType.SEPARATOR;
+                return;
+            }
+
+            if (tokenStart > equalsIndex) {
+                tokenEnd = lineEnd;
+                tokenType = QuickFixConfigTokenType.VALUE;
+                return;
+            }
+        }
+
+        tokenEnd = lineEnd;
+        tokenType = QuickFixConfigTokenType.VALUE;
+    }
+
+    private int findLineStart(int offset) {
+        int start = offset;
+        while (start > 0 && buffer.charAt(start - 1) != '\n') {
+            start--;
+        }
+        return start;
+    }
+
+    private int findLineEnd(int offset) {
+        int end = offset;
+        while (end < bufferEnd && buffer.charAt(end) != '\n') {
+            end++;
+        }
+        return end;
+    }
+
+    private int findFirstNonWhitespace(int start, int end) {
+        int offset = start;
+        while (offset < end && Character.isWhitespace(buffer.charAt(offset)) && buffer.charAt(offset) != '\n') {
+            offset++;
+        }
+        return offset;
+    }
+
+    private boolean isCommentStart(int offset, int lineEnd) {
+        char currentChar = buffer.charAt(offset);
+        if (currentChar == '#' || currentChar == ';') {
+            return true;
+        }
+        if (currentChar == '/' && offset + 1 < lineEnd && buffer.charAt(offset + 1) == '/') {
+            return true;
+        }
+        return false;
+    }
+
+    private int indexOf(char target, int start, int end) {
+        int offset = start;
+        while (offset < end) {
+            if (buffer.charAt(offset) == target) {
+                return offset;
+            }
+            offset++;
+        }
+        return -1;
+    }
+}

--- a/src/main/java/com/rannett/fixplugin/quickfix/QuickFixConfigSyntaxHighlighter.java
+++ b/src/main/java/com/rannett/fixplugin/quickfix/QuickFixConfigSyntaxHighlighter.java
@@ -1,0 +1,96 @@
+package com.rannett.fixplugin.quickfix;
+
+import com.intellij.lexer.Lexer;
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors;
+import com.intellij.openapi.editor.colors.TextAttributesKey;
+import com.intellij.openapi.fileTypes.SyntaxHighlighter;
+import com.intellij.psi.TokenType;
+import com.intellij.psi.tree.IElementType;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Syntax highlighter for QuickFIX session configuration files.
+ */
+public class QuickFixConfigSyntaxHighlighter implements SyntaxHighlighter {
+
+    /**
+     * Highlighting for section headers.
+     */
+    public static final TextAttributesKey SECTION = TextAttributesKey.createTextAttributesKey(
+            "QUICKFIX_CONFIG_SECTION",
+            DefaultLanguageHighlighterColors.METADATA
+    );
+    /**
+     * Highlighting for keys.
+     */
+    public static final TextAttributesKey KEY = TextAttributesKey.createTextAttributesKey(
+            "QUICKFIX_CONFIG_KEY",
+            DefaultLanguageHighlighterColors.KEYWORD
+    );
+    /**
+     * Highlighting for separators.
+     */
+    public static final TextAttributesKey SEPARATOR = TextAttributesKey.createTextAttributesKey(
+            "QUICKFIX_CONFIG_SEPARATOR",
+            DefaultLanguageHighlighterColors.OPERATION_SIGN
+    );
+    /**
+     * Highlighting for values.
+     */
+    public static final TextAttributesKey VALUE = TextAttributesKey.createTextAttributesKey(
+            "QUICKFIX_CONFIG_VALUE",
+            DefaultLanguageHighlighterColors.STRING
+    );
+    /**
+     * Highlighting for comments.
+     */
+    public static final TextAttributesKey COMMENT = TextAttributesKey.createTextAttributesKey(
+            "QUICKFIX_CONFIG_COMMENT",
+            DefaultLanguageHighlighterColors.LINE_COMMENT
+    );
+
+    private static final TextAttributesKey[] SECTION_KEYS = new TextAttributesKey[]{SECTION};
+    private static final TextAttributesKey[] KEY_KEYS = new TextAttributesKey[]{KEY};
+    private static final TextAttributesKey[] SEPARATOR_KEYS = new TextAttributesKey[]{SEPARATOR};
+    private static final TextAttributesKey[] VALUE_KEYS = new TextAttributesKey[]{VALUE};
+    private static final TextAttributesKey[] COMMENT_KEYS = new TextAttributesKey[]{COMMENT};
+    private static final TextAttributesKey[] EMPTY_KEYS = new TextAttributesKey[0];
+
+    /**
+     * Returns the lexer for this highlighter.
+     *
+     * @return the lexer.
+     */
+    @NotNull
+    @Override
+    public Lexer getHighlightingLexer() {
+        return new QuickFixConfigLexer();
+    }
+
+    /**
+     * Returns the highlighting attributes for the token.
+     *
+     * @param tokenType the token type.
+     * @return the text attributes for the token.
+     */
+    @NotNull
+    @Override
+    public TextAttributesKey[] getTokenHighlights(IElementType tokenType) {
+        if (tokenType == QuickFixConfigTokenType.SECTION) {
+            return SECTION_KEYS;
+        }
+        if (tokenType == QuickFixConfigTokenType.KEY) {
+            return KEY_KEYS;
+        }
+        if (tokenType == QuickFixConfigTokenType.SEPARATOR) {
+            return SEPARATOR_KEYS;
+        }
+        if (tokenType == QuickFixConfigTokenType.VALUE) {
+            return VALUE_KEYS;
+        }
+        if (tokenType == QuickFixConfigTokenType.COMMENT || tokenType == TokenType.BAD_CHARACTER) {
+            return COMMENT_KEYS;
+        }
+        return EMPTY_KEYS;
+    }
+}

--- a/src/main/java/com/rannett/fixplugin/quickfix/QuickFixConfigSyntaxHighlighterFactory.java
+++ b/src/main/java/com/rannett/fixplugin/quickfix/QuickFixConfigSyntaxHighlighterFactory.java
@@ -1,0 +1,27 @@
+package com.rannett.fixplugin.quickfix;
+
+import com.intellij.openapi.fileTypes.SyntaxHighlighter;
+import com.intellij.openapi.fileTypes.SyntaxHighlighterFactory;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Factory for QuickFIX session configuration syntax highlighters.
+ */
+public class QuickFixConfigSyntaxHighlighterFactory extends SyntaxHighlighterFactory {
+
+    /**
+     * Returns a syntax highlighter instance.
+     *
+     * @param project the current project.
+     * @param virtualFile the file to highlight.
+     * @return the syntax highlighter.
+     */
+    @NotNull
+    @Override
+    public SyntaxHighlighter getSyntaxHighlighter(@Nullable Project project, @Nullable VirtualFile virtualFile) {
+        return new QuickFixConfigSyntaxHighlighter();
+    }
+}

--- a/src/main/java/com/rannett/fixplugin/quickfix/QuickFixConfigTokenType.java
+++ b/src/main/java/com/rannett/fixplugin/quickfix/QuickFixConfigTokenType.java
@@ -1,0 +1,35 @@
+package com.rannett.fixplugin.quickfix;
+
+import com.intellij.psi.tree.IElementType;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Token types used for QuickFIX session configuration highlighting.
+ */
+public class QuickFixConfigTokenType extends IElementType {
+
+    /**
+     * Section header token.
+     */
+    public static final QuickFixConfigTokenType SECTION = new QuickFixConfigTokenType("SECTION");
+    /**
+     * Key token for configuration entries.
+     */
+    public static final QuickFixConfigTokenType KEY = new QuickFixConfigTokenType("KEY");
+    /**
+     * Separator token for '='.
+     */
+    public static final QuickFixConfigTokenType SEPARATOR = new QuickFixConfigTokenType("SEPARATOR");
+    /**
+     * Value token for configuration entries.
+     */
+    public static final QuickFixConfigTokenType VALUE = new QuickFixConfigTokenType("VALUE");
+    /**
+     * Comment token for configuration entries.
+     */
+    public static final QuickFixConfigTokenType COMMENT = new QuickFixConfigTokenType("COMMENT");
+
+    private QuickFixConfigTokenType(@NotNull String debugName) {
+        super(debugName, QuickFixConfigLanguage.INSTANCE);
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -19,13 +19,24 @@
                 fieldName="INSTANCE"
                 language="Fix"
                 extensions="fix"/>
+        <fileType
+                name="QuickFIX Session Config"
+                implementationClass="com.rannett.fixplugin.quickfix.QuickFixConfigFileType"
+                fieldName="INSTANCE"
+                language="QuickFixConfig"
+                extensions="fix.cfg,quickfix.cfg"/>
 
         <lang.parserDefinition language="Fix" implementationClass="com.rannett.fixplugin.FixParserDefinition"/>
         <lang.syntaxHighlighterFactory
                 language="Fix"
                 implementationClass="com.rannett.fixplugin.FixSyntaxHighlighterFactory"/>
+        <lang.syntaxHighlighterFactory
+                language="QuickFixConfig"
+                implementationClass="com.rannett.fixplugin.quickfix.QuickFixConfigSyntaxHighlighterFactory"/>
         <colorSettingsPage
                 implementation="com.rannett.fixplugin.FixColorSettingsPage"/>
+
+        <fileTypeDetector implementation="com.rannett.fixplugin.quickfix.QuickFixConfigFileTypeDetector"/>
 
         <localInspection language="Fix"
                          shortName="FixChecksumInspection"


### PR DESCRIPTION
### Motivation
- Recognise and colourise QuickFIX session configuration files using safe content-based detection rather than blind extension matching.
- Only claim files that actually look like QuickFIX configs (to keep false positives vanishingly unlikely) and still allow manual user association.
- Surface the feature in documentation and changelog so users know about the detection and how to override it.

### Description
- Added a QuickFIX config language and file type via `QuickFixConfigLanguage` and `QuickFixConfigFileType` for dedicated highlighting and file association.
- Implemented a simple lexer, token types, syntax highlighter and factory in `QuickFixConfigLexer`, `QuickFixConfigTokenType`, `QuickFixConfigSyntaxHighlighter`, and `QuickFixConfigSyntaxHighlighterFactory` to provide colourised sections, keys, separators, values and comments.
- Implemented `QuickFixConfigFileTypeDetector` that uses conservative, content-based heuristics (section headers like `[DEFAULT]`/`[SESSION]` and keys such as `BeginString=`, `SenderCompID=`, `TargetCompID=`, `ConnectionType=`) to detect QuickFIX configs before claiming a file type.
- Registered the file type, syntax highlighter and file type detector in `plugin.xml`, and added `fix.cfg`/`quickfix.cfg` handling while keeping content-based detection for other extensions.
- Updated `CHANGELOG.md` and `README.md` to document the new QuickFIX session config detection and the manual override via *Associate with File Type → QuickFIX Session Config*.

### Testing
- No automated tests were executed for this change. 
- Manual verification was not recorded in automated test logs, so build/IDE integration should be validated during review or CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698730b6c398832cad4c711db839f8ea)