### PR TITLE
Skip FIX language injection for Markdown files (avoid README examples being parsed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Prevent FIX language injection inside Markdown files so README/examples are not parsed as live FIX content.
 - Use locale-insensitive FIX type matching so validation stays accurate under non-English locales.
 - Avoid returning empty entries when splitting or extracting FIX messages from whitespace-only input.
 - Fix QuickFIX config file detection wiring for the IntelliJ 2024.2 file type detector API.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ There is also a tree view, to show the message structure, and a communications v
 - **Side-by-side diff viewer** for comparing two messages
 - **Log cleanup button** to strip non-FIX prefixes/suffixes and keep pure FIX messages in the editor
 - **Language injection** for FIX messages embedded in code strings
+- **Markdown-safe language injection** keeps FIX examples in `README.md` and other Markdown docs from being inspected as live FIX content.
 - **FpML Detection** for XML embedded in tags 351 and 213
 - **Lexer support** for multi-line FpML blocks
 - **Unlimited IDE compatibility** so the plugin can install on newer IntelliJ versions without a capped build range

--- a/src/main/java/com/rannett/fixplugin/injection/FixStringLanguageInjector.java
+++ b/src/main/java/com/rannett/fixplugin/injection/FixStringLanguageInjector.java
@@ -2,7 +2,9 @@ package com.rannett.fixplugin.injection;
 
 import com.intellij.lang.injection.MultiHostInjector;
 import com.intellij.lang.injection.MultiHostRegistrar;
+import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiLanguageInjectionHost;
 import com.rannett.fixplugin.FixLanguage;
@@ -24,6 +26,10 @@ public class FixStringLanguageInjector implements MultiHostInjector {
     @Override
     public void getLanguagesToInject(@NotNull MultiHostRegistrar registrar, @NotNull PsiElement context) {
         if (!(context instanceof PsiLanguageInjectionHost host) || !host.isValidHost()) {
+            return;
+        }
+
+        if (shouldSkipInjection(context)) {
             return;
         }
 
@@ -63,5 +69,17 @@ public class FixStringLanguageInjector implements MultiHostInjector {
     public @NotNull List<Class<? extends PsiElement>> elementsToInjectIn() {
         return List.of(PsiLanguageInjectionHost.class);
     }
-}
 
+    private boolean shouldSkipInjection(@NotNull PsiElement context) {
+        VirtualFile virtualFile = context.getContainingFile() == null ? null : context.getContainingFile().getVirtualFile();
+        if (virtualFile == null) {
+            return false;
+        }
+        String extension = virtualFile.getExtension();
+        if (extension != null && extension.equalsIgnoreCase("md")) {
+            return true;
+        }
+        FileType fileType = virtualFile.getFileType();
+        return fileType.getName().equalsIgnoreCase("Markdown");
+    }
+}

--- a/src/test/java/com/rannett/fixplugin/injection/FixStringLanguageInjectorTest.java
+++ b/src/test/java/com/rannett/fixplugin/injection/FixStringLanguageInjectorTest.java
@@ -20,5 +20,18 @@ public class FixStringLanguageInjectorTest extends BasePlatformTestCase {
         assertNull(InjectedLanguageManager.getInstance(getProject())
                 .findInjectedElementAt(myFixture.getFile(), offset));
     }
-}
 
+    public void testNoInjectionForMarkdownFixExample() {
+        String markdown = """
+                # Example
+
+                ```text
+                8=FIX.4.4|9=112|35=D|49=CLIENT12|56=BROKER34|10=004|
+                ```
+                """;
+        myFixture.configureByText("README.md", markdown);
+        int offset = myFixture.getFile().getText().indexOf("8=FIX.4.4") + 1;
+        assertNull(InjectedLanguageManager.getInstance(getProject())
+                .findInjectedElementAt(myFixture.getFile(), offset));
+    }
+}


### PR DESCRIPTION
### Motivation
- README and other Markdown docs can contain sample FIX messages which were being picked up by the language injector and treated as live FIX content, causing false-positive inspections and errors.
- Injection should continue to work for string literals in source files but not attempt to inject inside documentation files or code blocks in Markdown.

### Description
- Add a `shouldSkipInjection` guard to `FixStringLanguageInjector` that consults the host `VirtualFile` and skips injection for `.md` extensions and files whose `FileType` name is `Markdown`.
- Keep existing version-detection logic unchanged so injection still triggers for real string literals in source files when `FixUtils.extractFixVersion` returns a version.
- Add a regression test `testNoInjectionForMarkdownFixExample` in `FixStringLanguageInjectorTest` which configures `README.md` content containing a FIX example and asserts no injected FIX PSI element is created.
- Update `CHANGELOG.md` (Unreleased -> Fixed) and `README.md` feature list to document the new Markdown-safe behavior.

### Testing
- Ran the injector unit tests with `./gradlew test --tests com.rannett.fixplugin.injection.FixStringLanguageInjectorTest` and the build completed successfully (tests passed).
- Project compiled and test sandbox prepared as part of the test run with no failures reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb651a1068832cab72b0d9a6755a3b)