### PR TITLE
Add unit tests for four previously untested classes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Development Commands
+
+```bash
+./gradlew buildPlugin          # Build the plugin artifact
+./gradlew runIde               # Run the plugin in an IDE sandbox for manual testing
+./gradlew test                 # Run unit tests
+./gradlew check                # Run all tests + verifyPlugin
+./gradlew verifyPlugin         # Verify plugin structure and compatibility
+./gradlew runPluginVerifier    # Run IntelliJ Plugin Verifier across target IDE versions
+
+# Run a single test class
+./gradlew test --tests com.rannett.fixplugin.util.FixMessageParserTest
+```
+
+The lexer (`FixLexer.java`) is generated from `Fix.flex` using the bundled `jflex-1.9.2.jar`. Generated PSI classes live in `src/main/gen/` and are included in the source set.
+
+## Architecture
+
+This is a single-module IntelliJ Platform plugin (Gradle-based, `com.intellij.platform.gradle.plugin` v2, targeting IC 2024.2.6+, Java 17). The plugin provides language support, custom editors, and tooling for FIX protocol messages.
+
+### Language Core
+
+The FIX language pipeline follows the standard IntelliJ PSI model:
+
+- `Fix.flex` → `FixLexer` (generated) → `FixParser` → PSI tree, wired by `FixParserDefinition`
+- PSI types: `FixTokenType`, `FixElementType`, `FixTokenSets`; generated impl classes in `src/main/gen/`
+- `FixElementFactory` creates new PSI elements programmatically
+
+### Dictionary & Metadata
+
+- `FixTagDictionary` loads FIX field definitions from QuickFIX/J XML dictionaries (bundled in `resources/dictionaries/`)
+- `FixDictionaryCache` is a project-level service that caches `FixTagDictionary` instances per FIX version
+- `FixViewerSettingsState` persists user-configured dictionary mappings and other settings
+- `FixDocumentationProvider` surfaces hover tooltips for tags and enum values using the dictionary
+
+### Inspections & Annotators
+
+- `FixChecksumInspection` + `FixChecksumQuickFix` — validates tag 10 checksum, offers auto-correct
+- `FixInvalidCharAnnotator` — flags characters outside valid FIX range
+- `FixCheckTypeAnnotator` + `FieldTypeValidator` — validates field values against FIX type specs (INT, CHAR, etc.)
+
+### Custom Editor (FixDualViewEditor)
+
+`FixDualViewEditorProvider` registers a split/tabbed custom editor for `.fix` files. It hosts four views:
+
+1. **Table view** — `FixTransposedTablePanel` + `FixTransposedTableModel`: multi-message grid where columns are messages and rows are tags
+2. **Tree view** — `FixMessageTreePanel`: hierarchical group/repeating-group structure
+3. **Timeline view** — `FixCommTimelinePanel`: FIX session communication timeline
+4. **Text view** — native IntelliJ text editor
+
+### Tool Window
+
+`FixFieldLookupToolWindowFactory` + `FixFieldLookupPanel` provides a right-panel tool window for looking up FIX tag definitions.
+
+### QuickFIX Config Support
+
+Separate language (`QuickFixConfigLanguage`) for `.fix.cfg` / `.quickfix.cfg` files, with its own lexer, parser, file-type detector, and documentation provider. Tooltips are sourced from embedded QuickFIX/J reference data.
+
+### Utilities
+
+- `FixMessageParser` — wraps QuickFIX/J for parsing raw FIX message strings
+- `FixUtils` — helper functions for message manipulation
+- `FpmlUtils` — detects and handles FpML (XML) embedded in tags 351 and 213
+- `FixStringLanguageInjector` — injects FIX language into string literals in Java/Kotlin source
+
+## Coding Style
+
+- Full import statements — no wildcard `*` imports
+- Curly braces on all `if` statements, even single-line bodies
+- Javadoc required on all public methods
+- Prefer Java streams over `for` loops
+- Target Java 17; use modern APIs
+- Prefer explicit types over `var` unless the type is overly verbose
+- No new external dependencies without explicit approval
+
+## Constraints
+
+- Do not change FIX protocol semantics or modify the bundled default dictionaries
+- Do not push directly to `main`
+- When making changes, add a description to the `Unreleased` section of `CHANGELOG.md`

--- a/src/test/java/com/rannett/fixplugin/FixDocumentationProviderTest.java
+++ b/src/test/java/com/rannett/fixplugin/FixDocumentationProviderTest.java
@@ -1,0 +1,150 @@
+package com.rannett.fixplugin;
+
+import com.intellij.openapi.editor.Editor;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import com.rannett.fixplugin.psi.FixField;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class FixDocumentationProviderTest extends BasePlatformTestCase {
+
+    // The FIX lexer accepts | as a field delimiter in test files.
+    private static final String SEP = "|";
+
+    private FixDocumentationProvider provider;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        provider = new FixDocumentationProvider();
+    }
+
+    // -------------------------------------------------------------------------
+    // getCustomDocumentationElement
+    // -------------------------------------------------------------------------
+
+    public void testGetCustomDocumentationElement_nullContextElement_returnsNull() {
+        myFixture.configureByText("test.fix", "8=FIX.4.2" + SEP);
+        Editor editor = myFixture.getEditor();
+        PsiFile file = myFixture.getFile();
+        assertNull(provider.getCustomDocumentationElement(editor, file, null, 0));
+    }
+
+    public void testGetCustomDocumentationElement_tagElement_returnsElement() {
+        PsiElement[] elems = configure("8=FIX.4.2" + SEP + "35=D" + SEP + "10=000" + SEP);
+        PsiElement tag = elems[0];  // TAG element of field 0
+        Editor editor = myFixture.getEditor();
+        PsiFile file = myFixture.getFile();
+        assertSame(tag, provider.getCustomDocumentationElement(editor, file, tag, 0));
+    }
+
+    public void testGetCustomDocumentationElement_valueElement_returnsElement() {
+        myFixture.configureByText("test.fix", "8=FIX.4.2" + SEP + "35=D" + SEP + "10=000" + SEP);
+        PsiFile file = myFixture.getFile();
+        FixField field = firstField(file);
+        PsiElement value = field.getLastChild();
+        Editor editor = myFixture.getEditor();
+        assertSame(value, provider.getCustomDocumentationElement(editor, file, value, 0));
+    }
+
+    // -------------------------------------------------------------------------
+    // generateDoc — null / guard cases
+    // -------------------------------------------------------------------------
+
+    public void testGenerateDoc_nullElement_returnsNull() {
+        assertNull(provider.generateDoc(null, null));
+    }
+
+    // -------------------------------------------------------------------------
+    // generateDoc — known tag produces HTML
+    // -------------------------------------------------------------------------
+
+    public void testGenerateDoc_knownTag_containsTagNumberAndName() {
+        // Field at index 1 is 35=D (MsgType). Index 0 is the BeginString field.
+        PsiElement tag = tagAt("8=FIX.4.2" + SEP + "35=D" + SEP + "10=000" + SEP, 1);
+        String doc = provider.generateDoc(tag, null);
+        assertNotNull(doc);
+        assertTrue(doc.contains("35"));
+        assertTrue(doc.contains("MsgType"));
+    }
+
+    public void testGenerateDoc_knownTagWithEnumValue_containsValueName() {
+        // tag 35=D → the value text "D" and ideally its name should appear
+        PsiElement value = valueAt("8=FIX.4.2" + SEP + "35=D" + SEP + "10=000" + SEP, 1);
+        String doc = provider.generateDoc(value, null);
+        assertNotNull(doc);
+        assertTrue("Doc should include the value text", doc.contains("D"));
+    }
+
+    public void testGenerateDoc_knownTagWithFieldType_containsType() {
+        // tag 34 = MsgSeqNum, type INT in FIX.4.2
+        PsiElement tag = tagAt("8=FIX.4.2" + SEP + "34=1" + SEP + "10=000" + SEP, 1);
+        String doc = provider.generateDoc(tag, null);
+        assertNotNull(doc);
+        assertTrue("Doc should include the FIX field type", doc.contains("INT"));
+    }
+
+    public void testGenerateDoc_unknownTag_returnsNull() {
+        // tag 99999 is not in any bundled dictionary
+        PsiElement tag = tagAt("8=FIX.4.2" + SEP + "99999=X" + SEP + "10=000" + SEP, 1);
+        assertNull("Unknown tags should produce no documentation", provider.generateDoc(tag, null));
+    }
+
+    public void testGenerateDoc_usesVersionFromFileContent() {
+        // File has "8=FIX.4.2" → version FIX.4.2 should appear in the footer
+        PsiElement tag = tagAt("8=FIX.4.2" + SEP + "35=D" + SEP + "10=000" + SEP, 1);
+        String doc = provider.generateDoc(tag, null);
+        assertNotNull(doc);
+        assertTrue("Doc footer should show the resolved FIX version", doc.contains("FIX.4.2"));
+    }
+
+    public void testGenerateDoc_noVersionInFile_fallsBackToFixt11() {
+        // No BeginString field → falls back to FIXT.1.1
+        PsiElement tag = tagAt("35=D" + SEP + "10=000" + SEP, 0);
+        String doc = provider.generateDoc(tag, null);
+        // May be null if tag is unknown in FIXT.1.1 dictionary; must not throw.
+        if (doc != null) {
+            assertTrue("Fallback version should be FIXT.1.1", doc.contains("FIXT.1.1"));
+        }
+    }
+
+    public void testGenerateDoc_outputIsWellFormedHtml() {
+        PsiElement tag = tagAt("8=FIX.4.2" + SEP + "35=D" + SEP + "10=000" + SEP, 1);
+        String doc = provider.generateDoc(tag, null);
+        assertNotNull(doc);
+        assertTrue(doc.startsWith("<html>"));
+        assertTrue(doc.endsWith("</html>"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /** Configures the fixture and returns [tag, value] of the first field. */
+    private PsiElement[] configure(String fixContent) {
+        myFixture.configureByText("test.fix", fixContent);
+        FixField field = firstField(myFixture.getFile());
+        return new PsiElement[]{field.getFirstChild(), field.getLastChild()};
+    }
+
+    private FixField firstField(PsiFile file) {
+        Collection<FixField> fields = PsiTreeUtil.findChildrenOfType(file, FixField.class);
+        return new ArrayList<>(fields).get(0);
+    }
+
+    private PsiElement tagAt(String fixContent, int fieldIndex) {
+        myFixture.configureByText("test.fix", fixContent);
+        Collection<FixField> fields = PsiTreeUtil.findChildrenOfType(myFixture.getFile(), FixField.class);
+        return new ArrayList<>(fields).get(fieldIndex).getFirstChild();
+    }
+
+    private PsiElement valueAt(String fixContent, int fieldIndex) {
+        myFixture.configureByText("test.fix", fixContent);
+        Collection<FixField> fields = PsiTreeUtil.findChildrenOfType(myFixture.getFile(), FixField.class);
+        return new ArrayList<>(fields).get(fieldIndex).getLastChild();
+    }
+}

--- a/src/test/java/com/rannett/fixplugin/annotator/FixCheckTypeAnnotatorTest.java
+++ b/src/test/java/com/rannett/fixplugin/annotator/FixCheckTypeAnnotatorTest.java
@@ -1,0 +1,121 @@
+package com.rannett.fixplugin.annotator;
+
+import com.intellij.lang.annotation.HighlightSeverity;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+public class FixCheckTypeAnnotatorTest extends BasePlatformTestCase {
+
+    // The FIX lexer accepts | as a field delimiter in test files (same as in FixInvalidCharAnnotatorTest).
+    private static final String SEP = "|";
+
+    // A minimal FIX.4.2 message wrap so the annotator can extract the version.
+    private static final String PREFIX = "8=FIX.4.2" + SEP;
+    private static final String SUFFIX = "10=000" + SEP;
+
+    // -------------------------------------------------------------------------
+    // Valid values — no errors expected
+    // -------------------------------------------------------------------------
+
+    public void testValidIntValue_noAnnotation() {
+        // tag 34 (MsgSeqNum) has type INT
+        String message = PREFIX + "34=1" + SEP + SUFFIX;
+        myFixture.configureByText("test.fix", message);
+        boolean hasTypeError = myFixture.doHighlighting().stream()
+                .anyMatch(info -> info.getSeverity() == HighlightSeverity.ERROR
+                        && info.getDescription() != null
+                        && info.getDescription().startsWith("Invalid value for type"));
+        assertFalse("A valid INT value should produce no type error", hasTypeError);
+    }
+
+    public void testValidStringValue_noAnnotation() {
+        // tag 35 (MsgType) has type STRING — any value is valid
+        String message = PREFIX + "35=D" + SEP + SUFFIX;
+        myFixture.configureByText("test.fix", message);
+        boolean hasTypeError = myFixture.doHighlighting().stream()
+                .anyMatch(info -> info.getSeverity() == HighlightSeverity.ERROR
+                        && info.getDescription() != null
+                        && info.getDescription().startsWith("Invalid value for type"));
+        assertFalse("A valid STRING value should produce no type error", hasTypeError);
+    }
+
+    public void testValidNegativeIntValue_noAnnotation() {
+        // tag 34 INT; negative integers are valid per FieldTypeValidator
+        String message = PREFIX + "34=-5" + SEP + SUFFIX;
+        myFixture.configureByText("test.fix", message);
+        boolean hasTypeError = myFixture.doHighlighting().stream()
+                .anyMatch(info -> info.getSeverity() == HighlightSeverity.ERROR
+                        && info.getDescription() != null
+                        && info.getDescription().startsWith("Invalid value for type"));
+        assertFalse("A negative INT value should produce no type error", hasTypeError);
+    }
+
+    // -------------------------------------------------------------------------
+    // Invalid values — errors expected
+    // -------------------------------------------------------------------------
+
+    public void testInvalidIntValue_producesError() {
+        // tag 34 (MsgSeqNum) has type INT; "ABC" is not a valid integer
+        String message = PREFIX + "34=ABC" + SEP + SUFFIX;
+        myFixture.configureByText("test.fix", message);
+        boolean hasTypeError = myFixture.doHighlighting().stream()
+                .anyMatch(info -> info.getSeverity() == HighlightSeverity.ERROR
+                        && info.getDescription() != null
+                        && info.getDescription().startsWith("Invalid value for type INT"));
+        assertTrue("A non-integer value for an INT field should produce a type error", hasTypeError);
+    }
+
+    public void testInvalidIntValue_errorMessageContainsExpectedType() {
+        String message = PREFIX + "34=NOTANINT" + SEP + SUFFIX;
+        myFixture.configureByText("test.fix", message);
+        boolean found = myFixture.doHighlighting().stream()
+                .anyMatch(info -> info.getSeverity() == HighlightSeverity.ERROR
+                        && info.getDescription() != null
+                        && info.getDescription().contains("INT"));
+        assertTrue("Error annotation should name the expected FIX type", found);
+    }
+
+    // -------------------------------------------------------------------------
+    // Unknown tags — no errors (no type in dictionary → no annotation)
+    // -------------------------------------------------------------------------
+
+    public void testUnknownTag_noTypeAnnotation() {
+        // tag 99999 is not in the FIX.4.2 dictionary
+        String message = PREFIX + "99999=ANYTHING" + SEP + SUFFIX;
+        myFixture.configureByText("test.fix", message);
+        boolean hasTypeError = myFixture.doHighlighting().stream()
+                .anyMatch(info -> info.getSeverity() == HighlightSeverity.ERROR
+                        && info.getDescription() != null
+                        && info.getDescription().startsWith("Invalid value for type"));
+        assertFalse("Unknown tags have no type constraint and should not trigger a type error", hasTypeError);
+    }
+
+    // -------------------------------------------------------------------------
+    // Non-VALUE elements — annotator must skip TAG tokens
+    // -------------------------------------------------------------------------
+
+    public void testTagElement_isNotAnnotatedAsTypeError() {
+        // The annotator only fires on VALUE element types; TAG tokens must be ignored.
+        // A file with an invalid INT value on tag 34 should produce exactly one error
+        // (on the value), not two (one on the tag as well).
+        String message = PREFIX + "34=BAD" + SEP + SUFFIX;
+        myFixture.configureByText("test.fix", message);
+        long typeErrors = myFixture.doHighlighting().stream()
+                .filter(info -> info.getSeverity() == HighlightSeverity.ERROR
+                        && info.getDescription() != null
+                        && info.getDescription().startsWith("Invalid value for type"))
+                .count();
+        assertEquals("Exactly one type-error annotation expected (on the value, not the tag)", 1, typeErrors);
+    }
+
+    // -------------------------------------------------------------------------
+    // Version extraction — file without BeginString falls back to FIXT.1.1
+    // -------------------------------------------------------------------------
+
+    public void testFileWithoutVersion_fallsBackGracefully() {
+        // No tag 8 present; annotator must not throw and should apply FIXT.1.1 rules
+        String message = "34=ABC" + SEP + "10=000" + SEP;
+        myFixture.configureByText("test.fix", message);
+        // Just verify no exception is thrown and highlighting completes
+        assertNotNull(myFixture.doHighlighting());
+    }
+}

--- a/src/test/java/com/rannett/fixplugin/psi/impl/FixPsiImplUtilTest.java
+++ b/src/test/java/com/rannett/fixplugin/psi/impl/FixPsiImplUtilTest.java
@@ -1,0 +1,93 @@
+package com.rannett.fixplugin.psi.impl;
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import com.rannett.fixplugin.FixElementFactory;
+import com.rannett.fixplugin.psi.FixField;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class FixPsiImplUtilTest extends BasePlatformTestCase {
+
+    // -------------------------------------------------------------------------
+    // getTag
+    // -------------------------------------------------------------------------
+
+    public void testGetTag_returnsTagNumber() {
+        FixField field = FixElementFactory.createFixField(getProject(), "35", "D");
+        assertEquals("35", FixPsiImplUtil.getTag(field));
+    }
+
+    public void testGetTag_multiDigitTag_returnsFullNumber() {
+        FixField field = FixElementFactory.createFixField(getProject(), "1128", "9");
+        assertEquals("1128", FixPsiImplUtil.getTag(field));
+    }
+
+    public void testGetTag_singleDigitTag_returnsNumber() {
+        FixField field = FixElementFactory.createFixField(getProject(), "8", "FIX.4.2");
+        assertEquals("8", FixPsiImplUtil.getTag(field));
+    }
+
+    /**
+     * The source contains replaceAll("\\ ", " ") to convert escaped spaces.
+     * For normal numeric tags this is a no-op; verify it does not corrupt standard input.
+     */
+    public void testGetTag_normalTag_containsNoBackslash() {
+        FixField field = FixElementFactory.createFixField(getProject(), "49", "SENDER");
+        String tag = FixPsiImplUtil.getTag(field);
+        assertEquals("49", tag);
+        assertFalse("getTag should not introduce a backslash character", tag.contains("\\"));
+    }
+
+    // -------------------------------------------------------------------------
+    // getValue
+    // -------------------------------------------------------------------------
+
+    public void testGetValue_singleCharValue_returnsValue() {
+        FixField field = FixElementFactory.createFixField(getProject(), "35", "D");
+        assertEquals("D", FixPsiImplUtil.getValue(field));
+    }
+
+    public void testGetValue_numericValue_returnsAsString() {
+        FixField field = FixElementFactory.createFixField(getProject(), "34", "42");
+        assertEquals("42", FixPsiImplUtil.getValue(field));
+    }
+
+    public void testGetValue_multiCharValue_returnsFullText() {
+        FixField field = FixElementFactory.createFixField(getProject(), "8", "FIX.4.2");
+        assertEquals("FIX.4.2", FixPsiImplUtil.getValue(field));
+    }
+
+    public void testGetValue_alphanumericValue_returnsFullText() {
+        FixField field = FixElementFactory.createFixField(getProject(), "11", "ORD-001");
+        assertEquals("ORD-001", FixPsiImplUtil.getValue(field));
+    }
+
+    // -------------------------------------------------------------------------
+    // setValue
+    // -------------------------------------------------------------------------
+
+    public void testSetValue_changesValueText() {
+        FixField field = FixElementFactory.createFixField(getProject(), "35", "D");
+        assertEquals("D", FixPsiImplUtil.getValue(field));
+        FixPsiImplUtil.setValue(field, "8");
+        assertEquals("8", FixPsiImplUtil.getValue(field));
+    }
+
+    public void testSetValue_tagRemainsUnchanged() {
+        FixField field = FixElementFactory.createFixField(getProject(), "35", "D");
+        FixPsiImplUtil.setValue(field, "A");
+        assertEquals("35", FixPsiImplUtil.getTag(field));
+    }
+
+    public void testSetValue_returnsTheField() {
+        FixField field = FixElementFactory.createFixField(getProject(), "35", "D");
+        assertNotNull(FixPsiImplUtil.setValue(field, "A"));
+    }
+
+    public void testSetValue_multiCharNewValue_updatesCorrectly() {
+        FixField field = FixElementFactory.createFixField(getProject(), "49", "OLD");
+        FixPsiImplUtil.setValue(field, "NEWSENDER");
+        assertEquals("NEWSENDER", FixPsiImplUtil.getValue(field));
+    }
+}

--- a/src/test/java/com/rannett/fixplugin/settings/FixViewerSettingsStateTest.java
+++ b/src/test/java/com/rannett/fixplugin/settings/FixViewerSettingsStateTest.java
@@ -1,0 +1,191 @@
+package com.rannett.fixplugin.settings;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class FixViewerSettingsStateTest {
+
+    private FixViewerSettingsState state;
+
+    @Before
+    public void setUp() {
+        state = new FixViewerSettingsState();
+    }
+
+    // -------------------------------------------------------------------------
+    // ensureBuiltInDictionariesPresent
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void getDictionaryEntries_addsAllThreeBuiltInsWhenEmpty() {
+        List<FixViewerSettingsState.DictionaryEntry> entries = state.getDictionaryEntries();
+        assertEquals(3, entries.size());
+        assertTrue(entries.stream().anyMatch(e -> e.getVersion().equals("FIX.4.2") && e.isBuiltIn()));
+        assertTrue(entries.stream().anyMatch(e -> e.getVersion().equals("FIX.4.4") && e.isBuiltIn()));
+        assertTrue(entries.stream().anyMatch(e -> e.getVersion().equals("FIXT.1.1") && e.isBuiltIn()));
+    }
+
+    @Test
+    public void getDictionaryEntries_doesNotDuplicateBuiltInsOnRepeatedCalls() {
+        state.getDictionaryEntries();
+        state.getDictionaryEntries();
+        long count = state.getDictionaryEntries().stream()
+                .filter(e -> e.getVersion().equals("FIX.4.2") && e.isBuiltIn())
+                .count();
+        assertEquals(1, count);
+    }
+
+    @Test
+    public void setDictionaryEntries_preservesCustomEntryAndAddsBuiltIns() {
+        List<FixViewerSettingsState.DictionaryEntry> custom = new ArrayList<>();
+        custom.add(new FixViewerSettingsState.DictionaryEntry("FIX.4.2", "/custom.xml", false, true));
+        state.setDictionaryEntries(custom);
+
+        List<FixViewerSettingsState.DictionaryEntry> entries = state.getDictionaryEntries();
+        assertTrue(entries.stream().anyMatch(e -> "/custom.xml".equals(e.getPath())));
+        assertTrue(entries.stream().anyMatch(e -> e.getVersion().equals("FIX.4.4") && e.isBuiltIn()));
+        assertTrue(entries.stream().anyMatch(e -> e.getVersion().equals("FIXT.1.1") && e.isBuiltIn()));
+    }
+
+    // -------------------------------------------------------------------------
+    // getDefaultDictionary — fallback chain
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void getDefaultDictionary_withOnlyBuiltIn_returnsBuiltIn() {
+        FixViewerSettingsState.DictionaryEntry result = state.getDefaultDictionary("FIX.4.2");
+        assertNotNull(result);
+        assertTrue(result.isBuiltIn());
+        assertEquals("FIX.4.2", result.getVersion());
+    }
+
+    @Test
+    public void getDefaultDictionary_unknownVersion_returnsNull() {
+        assertNull(state.getDefaultDictionary("FIX.9.9"));
+    }
+
+    @Test
+    public void getDefaultDictionary_withCustomMarkedDefault_prefersCustomOverBuiltIn() {
+        List<FixViewerSettingsState.DictionaryEntry> entries = new ArrayList<>();
+        entries.add(new FixViewerSettingsState.DictionaryEntry("FIX.4.2", "/custom.xml", false, true));
+        state.setDictionaryEntries(entries);
+
+        FixViewerSettingsState.DictionaryEntry result = state.getDefaultDictionary("FIX.4.2");
+        assertNotNull(result);
+        assertFalse(result.isBuiltIn());
+        assertEquals("/custom.xml", result.getPath());
+    }
+
+    @Test
+    public void getDefaultDictionary_withCustomNotMarkedDefault_returnsBuiltIn() {
+        // ensureBuiltInDictionariesPresent always adds built-ins with defaultDictionary=true, so the
+        // built-in wins at tier 2 (any isDefaultDictionary()) when the custom has defaultDictionary=false.
+        List<FixViewerSettingsState.DictionaryEntry> entries = new ArrayList<>();
+        entries.add(new FixViewerSettingsState.DictionaryEntry("FIX.4.2", "/custom.xml", false, false));
+        state.setDictionaryEntries(entries);
+
+        FixViewerSettingsState.DictionaryEntry result = state.getDefaultDictionary("FIX.4.2");
+        assertNotNull(result);
+        assertTrue(result.isBuiltIn());
+    }
+
+    @Test
+    public void getDefaultDictionary_withMultipleCustom_prefersExplicitlyMarkedDefault() {
+        List<FixViewerSettingsState.DictionaryEntry> entries = new ArrayList<>();
+        entries.add(new FixViewerSettingsState.DictionaryEntry("FIX.4.2", "/first.xml", false, false));
+        entries.add(new FixViewerSettingsState.DictionaryEntry("FIX.4.2", "/second.xml", false, true));
+        state.setDictionaryEntries(entries);
+
+        FixViewerSettingsState.DictionaryEntry result = state.getDefaultDictionary("FIX.4.2");
+        assertNotNull(result);
+        assertEquals("/second.xml", result.getPath());
+    }
+
+    // -------------------------------------------------------------------------
+    // normalizeDefaults — exactly one default per version after setDictionaryEntries
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void setDictionaryEntries_withTwoCustomsBothDefault_normalizesToOneDefault() {
+        List<FixViewerSettingsState.DictionaryEntry> entries = new ArrayList<>();
+        entries.add(new FixViewerSettingsState.DictionaryEntry("FIX.4.2", "/first.xml", false, true));
+        entries.add(new FixViewerSettingsState.DictionaryEntry("FIX.4.2", "/second.xml", false, true));
+        state.setDictionaryEntries(entries);
+
+        long defaultCount = state.getDictionariesForVersion("FIX.4.2").stream()
+                .filter(FixViewerSettingsState.DictionaryEntry::isDefaultDictionary)
+                .count();
+        assertEquals(1, defaultCount);
+    }
+
+    @Test
+    public void setDictionaryEntries_withNoCustomDefault_builtInBecomesDefault() {
+        List<FixViewerSettingsState.DictionaryEntry> entries = new ArrayList<>();
+        state.setDictionaryEntries(entries);
+
+        FixViewerSettingsState.DictionaryEntry def = state.getDefaultDictionary("FIX.4.2");
+        assertNotNull(def);
+        assertTrue(def.isBuiltIn());
+    }
+
+    // -------------------------------------------------------------------------
+    // getDictionariesForVersion
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void getDictionariesForVersion_returnsOnlyEntriesForThatVersion() {
+        List<FixViewerSettingsState.DictionaryEntry> result = state.getDictionariesForVersion("FIX.4.2");
+        assertTrue(result.stream().allMatch(e -> e.getVersion().equals("FIX.4.2")));
+        assertFalse(result.isEmpty());
+    }
+
+    @Test
+    public void getDictionariesForVersion_unknownVersion_returnsEmptyList() {
+        assertTrue(state.getDictionariesForVersion("FIX.9.9").isEmpty());
+    }
+
+    // -------------------------------------------------------------------------
+    // DictionaryEntry.getCacheKey
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void getCacheKey_builtIn_prefixedWithBUILTIN() {
+        FixViewerSettingsState.DictionaryEntry entry = FixViewerSettingsState.DictionaryEntry.builtIn("FIX.4.2");
+        assertEquals("BUILTIN:FIX.4.2", entry.getCacheKey());
+    }
+
+    @Test
+    public void getCacheKey_custom_prefixedWithCUSTOM() {
+        FixViewerSettingsState.DictionaryEntry entry =
+                new FixViewerSettingsState.DictionaryEntry("FIX.4.2", "/my/dict.xml", false, false);
+        assertEquals("CUSTOM:/my/dict.xml", entry.getCacheKey());
+    }
+
+    // -------------------------------------------------------------------------
+    // DictionaryEntry.toString
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void toString_builtIn_includesBundledLabel() {
+        FixViewerSettingsState.DictionaryEntry entry = FixViewerSettingsState.DictionaryEntry.builtIn("FIX.4.2");
+        String str = entry.toString();
+        assertTrue(str.contains("FIX.4.2"));
+        assertTrue(str.contains("Built-in"));
+        assertTrue(str.contains("Bundled"));
+    }
+
+    @Test
+    public void toString_custom_includesPath() {
+        FixViewerSettingsState.DictionaryEntry entry =
+                new FixViewerSettingsState.DictionaryEntry("FIX.4.2", "/my/dict.xml", false, false);
+        String str = entry.toString();
+        assertTrue(str.contains("FIX.4.2"));
+        assertTrue(str.contains("Custom"));
+        assertTrue(str.contains("/my/dict.xml"));
+    }
+}


### PR DESCRIPTION
## Summary

- 47 new tests across 4 classes that had zero coverage: \`FixViewerSettingsState\`, \`FixDocumentationProvider\`, \`FixPsiImplUtil\`, and \`FixCheckTypeAnnotator\`
- Adds \`CLAUDE.md\` with build commands, architecture overview, and coding conventions

## What each test class covers

**FixViewerSettingsStateTest** (16 tests) — pure JUnit, no IntelliJ harness needed
- Multi-tier fallback chain in \`getDefaultDictionary()\`
- \`ensureBuiltInDictionariesPresent\` idempotency and \`normalizeDefaults\` behaviour

**FixDocumentationProviderTest** (11 tests)
- \`getCustomDocumentationElement()\` element-type routing
- \`generateDoc()\` HTML: tag name, field type, enum values, version footer, unknown-tag null

**FixPsiImplUtilTest** (12 tests)
- \`getTag()\` / \`getValue()\` / \`setValue()\` as direct static method calls

**FixCheckTypeAnnotatorTest** (8 tests)
- INT validation fires on bad values, suppressed for unknown tags and TAG tokens
- Graceful fallback when no BeginString is present

## Test plan
- [x] All 47 tests pass locally (\`JAVA_HOME=... ./gradlew test\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)