### PR TITLE
Auto-detect multi-part QuickFIX session config filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Upgraded QuickFIX/J core dependency from 2.3.2 to 3.0.0 and updated parser API usage for the new validation-settings signature.
 - Replaced removed QuickFIX/J generated field constants with stable FIX tag literals for EncodedSecurityDescLen/EncodedSecurityDesc (350/351).
+- QuickFIX session config files with multi-part names such as `*.fix.cfg` and `*.quickfix.cfg` now auto-associate with the QuickFIX Session Config file type.
 
 ## [0.0.21] - 2026-05-06
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ There is also a tree view, to show the message structure, and a communications v
 - **Message Hiding** in the transposed view for large message files
 - **Enumerated Values** suggested as items in the table view
 - **Override Dictionaries** with bespoke ones. Standard Quickfix dictionaries are used.
-- **QuickFIX session config detection** with dedicated highlighting, safe content-based recognition for config files, and manual association via *Associate with File Type → QuickFIX Session Config*.
+- **QuickFIX session config auto-association** now recognizes multi-part filenames like `*.fix.cfg` and `*.quickfix.cfg` automatically, with dedicated highlighting plus content-based fallback detection.
 - **QuickFIX session config tooltips** that describe configuration keys, accepted values, and defaults from the QuickFIX/J reference.
 - **QuickFIX session config value validation** that flags invalid settings based on the QuickFIX/J valid-values list.
 - **QuickFIX session network value validation** now accepts IPv4, IPv6, hostnames, and comma-separated address lists for InetAddress-based settings.

--- a/src/main/java/com/rannett/fixplugin/quickfix/QuickFixConfigFileTypeDetector.java
+++ b/src/main/java/com/rannett/fixplugin/quickfix/QuickFixConfigFileTypeDetector.java
@@ -15,6 +15,8 @@ import java.util.regex.Pattern;
 public class QuickFixConfigFileTypeDetector implements FileTypeRegistry.FileTypeDetector {
 
     private static final int MAX_SAMPLE_SIZE = 8192;
+    private static final String FIX_CFG_SUFFIX = ".fix.cfg";
+    private static final String QUICKFIX_CFG_SUFFIX = ".quickfix.cfg";
     private static final Pattern SECTION_PATTERN = Pattern.compile("(?m)^\\s*\\[(DEFAULT|SESSION)]\\s*$");
     private static final Pattern KEY_PATTERN = Pattern.compile(
             "(?m)^\\s*(BeginString|SenderCompID|TargetCompID|ConnectionType)\\s*="
@@ -33,6 +35,10 @@ public class QuickFixConfigFileTypeDetector implements FileTypeRegistry.FileType
     public FileType detect(@NotNull VirtualFile file,
                            @NotNull ByteSequence firstBytes,
                            @Nullable CharSequence firstCharsIfText) {
+        String fileName = file.getName().toLowerCase();
+        if (fileName.endsWith(FIX_CFG_SUFFIX) || fileName.endsWith(QUICKFIX_CFG_SUFFIX)) {
+            return QuickFixConfigFileType.INSTANCE;
+        }
         if (firstCharsIfText == null || !looksLikeQuickFixConfig(firstCharsIfText)) {
             return null;
         }


### PR DESCRIPTION
### Motivation
- Users reported that files named with multi-part suffixes like `client.fix.cfg` or `session.quickfix.cfg` were not being auto-associated with the QuickFIX Session Config file type and required manual association.

### Description
- Add explicit filename-suffix checks for `*.fix.cfg` and `*.quickfix.cfg` in `QuickFixConfigFileTypeDetector` so those files are immediately recognized before falling back to content-based heuristics.
- Preserve the existing content-based detection logic as a fallback and keep file-type behavior unchanged for files without a recognized suffix.
- Document the fix in `CHANGELOG.md` (Unreleased → Fixed) and update the `README.md` feature list to mention automatic multi-part filename association.

### Testing
- Ran the targeted unit test `./gradlew test --tests com.rannett.fixplugin.util.FixMessageSplitTest` which completed successfully.
- Ran the full test task `./gradlew test` and the build reported `BUILD SUCCESSFUL`, with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a019855db60832c82e30b8657c65f56)