### PR TITLE
Add FIX dictionary XML detection, editor tab, and field-definition navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Raise dictionary editor/navigation diagnostics to warning-level log entries and include goto-handler traces for easier troubleshooting.
 - Return XML attribute declaration targets (instead of attribute value leaf nodes) to improve reliability of jump navigation.
 - Add caret-offset fallback lookup in goto-declaration handling to recover when IntelliJ reports `XmlTokenImpl` without a direct `XmlAttributeValue` parent.
+- Add XmlTag-based fallback recovery in goto-declaration handling to resolve from enclosing message/group `<field>` tags when attribute-value PSI is missing.
 
 ## [0.0.21] - 2026-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Prioritize caret-near `<field>` tag resolution (excluding `<fields>` definitions) before attribute-value PSI paths to improve Ctrl+Click reliability across dictionary sections.
 - Fix right-click `Go to FIX Field Definition` visibility by deriving PSI from the active editor document when popup PSI context is unavailable.
 - Remove temporary verbose warning logs from dictionary navigation/editor paths after stabilizing fallback behavior.
+- Add dictionary navigation support for component references, resolving `<component name=\"...\"/>` to `<components><component .../>` definitions.
 
 ## [0.0.21] - 2026-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@
 - Fix right-click `Go to FIX Field Definition` visibility by deriving PSI from the active editor document when popup PSI context is unavailable.
 - Remove temporary verbose warning logs from dictionary navigation/editor paths after stabilizing fallback behavior.
 - Add dictionary navigation support for component references, resolving `<component name=\"...\"/>` to `<components><component .../>` definitions.
+- Fix dictionary XML reference-provider parent-tag checks so message-level `<field name=\"...\"/>` references produce navigation references correctly.
+- Tighten dictionary detection to require `<fix>` as the XML document root, reducing false-positive activation in unrelated XML files.
+- Resolve static-analysis warnings for nullability override annotations, sentence capitalization in dictionary-view header text, and redundant constant-condition checks.
 
 ## [0.0.21] - 2026-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Added
 
 - Added split-message coverage for embedded XML data fields (212/213) and multi-message parsing with mixed valid/malformed input.
+- Detect QuickFIX dictionary XML files and open a dedicated `FIX Dictionary` file-editor tab alongside the default XML editor.
+- Add dictionary-aware navigation for message-level field references to their `<fields>` definitions.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Return XML attribute declaration targets (instead of attribute value leaf nodes) to improve reliability of jump navigation.
 - Add caret-offset fallback lookup in goto-declaration handling to recover when IntelliJ reports `XmlTokenImpl` without a direct `XmlAttributeValue` parent.
 - Add XmlTag-based fallback recovery in goto-declaration handling to resolve from enclosing message/group `<field>` tags when attribute-value PSI is missing.
+- Prioritize caret-near `<field>` tag resolution (excluding `<fields>` definitions) before attribute-value PSI paths to improve Ctrl+Click reliability across dictionary sections.
 
 ## [0.0.21] - 2026-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Upgraded QuickFIX/J core dependency from 2.3.2 to 3.0.0 and updated parser API usage for the new validation-settings signature.
 - Replaced removed QuickFIX/J generated field constants with stable FIX tag literals for EncodedSecurityDescLen/EncodedSecurityDesc (350/351).
 - QuickFIX session config files with multi-part names such as `*.fix.cfg` and `*.quickfix.cfg` now auto-associate with the QuickFIX Session Config file type.
+- Override `FileEditor#getFile()` in the `FIX Dictionary` editor to satisfy IntelliJ's non-deprecated FileEditor contract and prevent runtime PluginException warnings.
 
 ## [0.0.21] - 2026-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 - Add caret-offset fallback lookup in goto-declaration handling to recover when IntelliJ reports `XmlTokenImpl` without a direct `XmlAttributeValue` parent.
 - Add XmlTag-based fallback recovery in goto-declaration handling to resolve from enclosing message/group `<field>` tags when attribute-value PSI is missing.
 - Prioritize caret-near `<field>` tag resolution (excluding `<fields>` definitions) before attribute-value PSI paths to improve Ctrl+Click reliability across dictionary sections.
+- Fix right-click `Go to FIX Field Definition` visibility by deriving PSI from the active editor document when popup PSI context is unavailable.
+- Remove temporary verbose warning logs from dictionary navigation/editor paths after stabilizing fallback behavior.
 
 ## [0.0.21] - 2026-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - QuickFIX session config files with multi-part names such as `*.fix.cfg` and `*.quickfix.cfg` now auto-associate with the QuickFIX Session Config file type.
 - Override `FileEditor#getFile()` in the `FIX Dictionary` editor to satisfy IntelliJ's non-deprecated FileEditor contract and prevent runtime PluginException warnings.
 - Fix dictionary field-reference PSI targeting so Ctrl+Click navigation now resolves reliably from message-level field `name` values to the canonical field definition.
+- Add an explicit dictionary XML `GotoDeclarationHandler` fallback so Ctrl+Click / Go To Declaration works even when PSI reference navigation is not invoked by the editor path.
 
 ## [0.0.21] - 2026-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Add diagnostic logging for dictionary editor acceptance/creation and right-click navigation attempts to aid troubleshooting in IDE logs.
 - Raise dictionary editor/navigation diagnostics to warning-level log entries and include goto-handler traces for easier troubleshooting.
 - Return XML attribute declaration targets (instead of attribute value leaf nodes) to improve reliability of jump navigation.
+- Add caret-offset fallback lookup in goto-declaration handling to recover when IntelliJ reports `XmlTokenImpl` without a direct `XmlAttributeValue` parent.
 
 ## [0.0.21] - 2026-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Replaced removed QuickFIX/J generated field constants with stable FIX tag literals for EncodedSecurityDescLen/EncodedSecurityDesc (350/351).
 - QuickFIX session config files with multi-part names such as `*.fix.cfg` and `*.quickfix.cfg` now auto-associate with the QuickFIX Session Config file type.
 - Override `FileEditor#getFile()` in the `FIX Dictionary` editor to satisfy IntelliJ's non-deprecated FileEditor contract and prevent runtime PluginException warnings.
+- Fix dictionary field-reference PSI targeting so Ctrl+Click navigation now resolves reliably from message-level field `name` values to the canonical field definition.
 
 ## [0.0.21] - 2026-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 - Add a right-click editor action (`Go to FIX Field Definition`) for dictionary message/group field references as a manual navigation fallback.
 - Improve dictionary navigation robustness by resolving from the nearest parent `XmlAttributeValue`, so Ctrl+Click/right-click works when caret lands on nested XML tokens.
 - Add diagnostic logging for dictionary editor acceptance/creation and right-click navigation attempts to aid troubleshooting in IDE logs.
+- Raise dictionary editor/navigation diagnostics to warning-level log entries and include goto-handler traces for easier troubleshooting.
+- Return XML attribute declaration targets (instead of attribute value leaf nodes) to improve reliability of jump navigation.
 
 ## [0.0.21] - 2026-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 - Fix dictionary field-reference PSI targeting so Ctrl+Click navigation now resolves reliably from message-level field `name` values to the canonical field definition.
 - Add an explicit dictionary XML `GotoDeclarationHandler` fallback so Ctrl+Click / Go To Declaration works even when PSI reference navigation is not invoked by the editor path.
 - Add a right-click editor action (`Go to FIX Field Definition`) for dictionary message/group field references as a manual navigation fallback.
+- Improve dictionary navigation robustness by resolving from the nearest parent `XmlAttributeValue`, so Ctrl+Click/right-click works when caret lands on nested XML tokens.
+- Add diagnostic logging for dictionary editor acceptance/creation and right-click navigation attempts to aid troubleshooting in IDE logs.
 
 ## [0.0.21] - 2026-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Override `FileEditor#getFile()` in the `FIX Dictionary` editor to satisfy IntelliJ's non-deprecated FileEditor contract and prevent runtime PluginException warnings.
 - Fix dictionary field-reference PSI targeting so Ctrl+Click navigation now resolves reliably from message-level field `name` values to the canonical field definition.
 - Add an explicit dictionary XML `GotoDeclarationHandler` fallback so Ctrl+Click / Go To Declaration works even when PSI reference navigation is not invoked by the editor path.
+- Add a right-click editor action (`Go to FIX Field Definition`) for dictionary message/group field references as a manual navigation fallback.
 
 ## [0.0.21] - 2026-05-06
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ There is also a tree view, to show the message structure, and a communications v
 - **Caret-offset fallback resolution** for Go To Declaration retries adjacent PSI elements when IntelliJ reports a non-value token under caret.
 - **XmlTag fallback navigation recovery** attempts resolution from the enclosing `<field ...>` tag when no direct XML attribute-value PSI is available at caret.
 - **Tag-first declaration resolution** now prioritizes caret-near `<field>` tags (outside `<fields>`) for more reliable Ctrl+Click in message/header/trailer/component contexts.
+- **Context-menu visibility hardening** now shows `Go to FIX Field Definition` reliably in the editor popup by resolving PSI from the active editor document when popup PSI context is missing.
 - **Modern FileEditor API compatibility** ensures the dictionary editor integrates cleanly with current IntelliJ platform expectations.
 - **Side-by-side diff viewer** for comparing two messages
 - **Log cleanup button** to strip non-FIX prefixes/suffixes and keep pure FIX messages in the editor

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ There is also a tree view, to show the message structure, and a communications v
 - **QuickFIX dictionary XML detection** automatically recognizes dictionary-style XML files (`<fix>` root plus key dictionary sections).
 - **FIX Dictionary editor tab** adds a dedicated `FIX Dictionary` view while preserving the standard XML editor.
 - **Dictionary-aware field navigation** resolves message-level field references (for example `<message><field name=\"SettlInstReqID\"/>`) to canonical definitions under `<fields>`.
+- **Ctrl+Click dictionary navigation** jumps directly from `<message><field name=\"...\"/>` to the matching `<fields><field .../>` definition in QuickFIX dictionary XML.
 - **Modern FileEditor API compatibility** ensures the dictionary editor integrates cleanly with current IntelliJ platform expectations.
 - **Side-by-side diff viewer** for comparing two messages
 - **Log cleanup button** to strip non-FIX prefixes/suffixes and keep pure FIX messages in the editor

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ There is also a tree view, to show the message structure, and a communications v
 - **Dictionary-aware field navigation** resolves message-level field references (for example `<message><field name=\"SettlInstReqID\"/>`) to canonical definitions under `<fields>`.
 - **Ctrl+Click dictionary navigation** jumps directly from `<message><field name=\"...\"/>` to the matching `<fields><field .../>` definition in QuickFIX dictionary XML.
 - **Goto Declaration support for dictionaries** adds explicit IntelliJ declaration handling for XML field references so Ctrl+Click/Go To Declaration resolves consistently.
+- **Right-click dictionary navigation action** adds `Go to FIX Field Definition` in the editor context menu for message/group field references.
 - **Modern FileEditor API compatibility** ensures the dictionary editor integrates cleanly with current IntelliJ platform expectations.
 - **Side-by-side diff viewer** for comparing two messages
 - **Log cleanup button** to strip non-FIX prefixes/suffixes and keep pure FIX messages in the editor

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ There is also a tree view, to show the message structure, and a communications v
 - **QuickFIX dictionary XML detection** automatically recognizes dictionary-style XML files (`<fix>` root plus key dictionary sections).
 - **FIX Dictionary editor tab** adds a dedicated `FIX Dictionary` view while preserving the standard XML editor.
 - **Dictionary-aware field navigation** resolves message-level field references (for example `<message><field name=\"SettlInstReqID\"/>`) to canonical definitions under `<fields>`.
+- **Modern FileEditor API compatibility** ensures the dictionary editor integrates cleanly with current IntelliJ platform expectations.
 - **Side-by-side diff viewer** for comparing two messages
 - **Log cleanup button** to strip non-FIX prefixes/suffixes and keep pure FIX messages in the editor
 - **Language injection** for FIX messages embedded in code strings

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ There is also a tree view, to show the message structure, and a communications v
 - **Actionable dictionary log traces** now emit warning-level entries from editor-selection and navigation handlers so diagnostics are visible in standard IDE logs.
 - **Caret-offset fallback resolution** for Go To Declaration retries adjacent PSI elements when IntelliJ reports a non-value token under caret.
 - **XmlTag fallback navigation recovery** attempts resolution from the enclosing `<field ...>` tag when no direct XML attribute-value PSI is available at caret.
+- **Tag-first declaration resolution** now prioritizes caret-near `<field>` tags (outside `<fields>`) for more reliable Ctrl+Click in message/header/trailer/component contexts.
 - **Modern FileEditor API compatibility** ensures the dictionary editor integrates cleanly with current IntelliJ platform expectations.
 - **Side-by-side diff viewer** for comparing two messages
 - **Log cleanup button** to strip non-FIX prefixes/suffixes and keep pure FIX messages in the editor

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ There is also a tree view, to show the message structure, and a communications v
 - **Validator quality hardening** includes static-analysis-friendly functional Optional handling in QuickFIX config validation logic.
 - **Dictionary selector** lists bundled and custom dictionaries per FIX version so you can switch parsing dynamically from the viewers.
 - **Dictionary Indicator** shows whether each FIX version uses the default or a modified dictionary directly in the viewers and lets you mark defaults per FIX version.
+- **QuickFIX dictionary XML detection** automatically recognizes dictionary-style XML files (`<fix>` root plus key dictionary sections).
+- **FIX Dictionary editor tab** adds a dedicated `FIX Dictionary` view while preserving the standard XML editor.
+- **Dictionary-aware field navigation** resolves message-level field references (for example `<message><field name=\"SettlInstReqID\"/>`) to canonical definitions under `<fields>`.
 - **Side-by-side diff viewer** for comparing two messages
 - **Log cleanup button** to strip non-FIX prefixes/suffixes and keep pure FIX messages in the editor
 - **Language injection** for FIX messages embedded in code strings

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ There is also a tree view, to show the message structure, and a communications v
 - **Dictionary navigation debug logging** writes editor acceptance/navigation traces to IntelliJ logs to diagnose configuration or caret-resolution issues.
 - **Actionable dictionary log traces** now emit warning-level entries from editor-selection and navigation handlers so diagnostics are visible in standard IDE logs.
 - **Caret-offset fallback resolution** for Go To Declaration retries adjacent PSI elements when IntelliJ reports a non-value token under caret.
+- **XmlTag fallback navigation recovery** attempts resolution from the enclosing `<field ...>` tag when no direct XML attribute-value PSI is available at caret.
 - **Modern FileEditor API compatibility** ensures the dictionary editor integrates cleanly with current IntelliJ platform expectations.
 - **Side-by-side diff viewer** for comparing two messages
 - **Log cleanup button** to strip non-FIX prefixes/suffixes and keep pure FIX messages in the editor

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ There is also a tree view, to show the message structure, and a communications v
 - **XmlTag fallback navigation recovery** attempts resolution from the enclosing `<field ...>` tag when no direct XML attribute-value PSI is available at caret.
 - **Tag-first declaration resolution** now prioritizes caret-near `<field>` tags (outside `<fields>`) for more reliable Ctrl+Click in message/header/trailer/component contexts.
 - **Context-menu visibility hardening** now shows `Go to FIX Field Definition` reliably in the editor popup by resolving PSI from the active editor document when popup PSI context is missing.
+- **Component reference navigation** now resolves `<component name="..."/>` usages (for example `Instrument`) to canonical definitions under `<components>`.
 - **Modern FileEditor API compatibility** ensures the dictionary editor integrates cleanly with current IntelliJ platform expectations.
 - **Side-by-side diff viewer** for comparing two messages
 - **Log cleanup button** to strip non-FIX prefixes/suffixes and keep pure FIX messages in the editor

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ There is also a tree view, to show the message structure, and a communications v
 - **Ctrl+Click dictionary navigation** jumps directly from `<message><field name=\"...\"/>` to the matching `<fields><field .../>` definition in QuickFIX dictionary XML.
 - **Goto Declaration support for dictionaries** adds explicit IntelliJ declaration handling for XML field references so Ctrl+Click/Go To Declaration resolves consistently.
 - **Right-click dictionary navigation action** adds `Go to FIX Field Definition` in the editor context menu for message/group field references.
+- **Visible FIX Dictionary view header** clearly indicates when the custom dictionary editor tab is active.
+- **Dictionary navigation debug logging** writes editor acceptance/navigation traces to IntelliJ logs to diagnose configuration or caret-resolution issues.
 - **Modern FileEditor API compatibility** ensures the dictionary editor integrates cleanly with current IntelliJ platform expectations.
 - **Side-by-side diff viewer** for comparing two messages
 - **Log cleanup button** to strip non-FIX prefixes/suffixes and keep pure FIX messages in the editor

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ There is also a tree view, to show the message structure, and a communications v
 - **Visible FIX Dictionary view header** clearly indicates when the custom dictionary editor tab is active.
 - **Dictionary navigation debug logging** writes editor acceptance/navigation traces to IntelliJ logs to diagnose configuration or caret-resolution issues.
 - **Actionable dictionary log traces** now emit warning-level entries from editor-selection and navigation handlers so diagnostics are visible in standard IDE logs.
+- **Caret-offset fallback resolution** for Go To Declaration retries adjacent PSI elements when IntelliJ reports a non-value token under caret.
 - **Modern FileEditor API compatibility** ensures the dictionary editor integrates cleanly with current IntelliJ platform expectations.
 - **Side-by-side diff viewer** for comparing two messages
 - **Log cleanup button** to strip non-FIX prefixes/suffixes and keep pure FIX messages in the editor

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ There is also a tree view, to show the message structure, and a communications v
 - **Right-click dictionary navigation action** adds `Go to FIX Field Definition` in the editor context menu for message/group field references.
 - **Visible FIX Dictionary view header** clearly indicates when the custom dictionary editor tab is active.
 - **Dictionary navigation debug logging** writes editor acceptance/navigation traces to IntelliJ logs to diagnose configuration or caret-resolution issues.
+- **Actionable dictionary log traces** now emit warning-level entries from editor-selection and navigation handlers so diagnostics are visible in standard IDE logs.
 - **Modern FileEditor API compatibility** ensures the dictionary editor integrates cleanly with current IntelliJ platform expectations.
 - **Side-by-side diff viewer** for comparing two messages
 - **Log cleanup button** to strip non-FIX prefixes/suffixes and keep pure FIX messages in the editor

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ There is also a tree view, to show the message structure, and a communications v
 - **Tag-first declaration resolution** now prioritizes caret-near `<field>` tags (outside `<fields>`) for more reliable Ctrl+Click in message/header/trailer/component contexts.
 - **Context-menu visibility hardening** now shows `Go to FIX Field Definition` reliably in the editor popup by resolving PSI from the active editor document when popup PSI context is missing.
 - **Component reference navigation** now resolves `<component name="..."/>` usages (for example `Instrument`) to canonical definitions under `<components>`.
+- **Safer dictionary detection** now requires the document root element to be `<fix>` (not just any nested `<fix>` substring).
+- **Reference-provider correctness hardening** now validates the direct parent `<field>` tag before checking its containing `<message>` context.
 - **Modern FileEditor API compatibility** ensures the dictionary editor integrates cleanly with current IntelliJ platform expectations.
 - **Side-by-side diff viewer** for comparing two messages
 - **Log cleanup button** to strip non-FIX prefixes/suffixes and keep pure FIX messages in the editor

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ There is also a tree view, to show the message structure, and a communications v
 - **FIX Dictionary editor tab** adds a dedicated `FIX Dictionary` view while preserving the standard XML editor.
 - **Dictionary-aware field navigation** resolves message-level field references (for example `<message><field name=\"SettlInstReqID\"/>`) to canonical definitions under `<fields>`.
 - **Ctrl+Click dictionary navigation** jumps directly from `<message><field name=\"...\"/>` to the matching `<fields><field .../>` definition in QuickFIX dictionary XML.
+- **Goto Declaration support for dictionaries** adds explicit IntelliJ declaration handling for XML field references so Ctrl+Click/Go To Declaration resolves consistently.
 - **Modern FileEditor API compatibility** ensures the dictionary editor integrates cleanly with current IntelliJ platform expectations.
 - **Side-by-side diff viewer** for comparing two messages
 - **Log cleanup button** to strip non-FIX prefixes/suffixes and keep pure FIX messages in the editor

--- a/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryFieldReference.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryFieldReference.java
@@ -1,0 +1,46 @@
+package com.rannett.fixplugin.dictionary;
+
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReferenceBase;
+import com.intellij.psi.xml.XmlAttribute;
+import com.intellij.psi.xml.XmlTag;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class FixDictionaryFieldReference extends PsiReferenceBase<XmlAttribute> {
+
+    public FixDictionaryFieldReference(@NotNull XmlAttribute element, @NotNull TextRange rangeInElement) {
+        super(element, rangeInElement);
+    }
+
+    @Override
+    public @Nullable PsiElement resolve() {
+        String fieldName = myElement.getValue();
+        if (fieldName == null || fieldName.isBlank()) {
+            return null;
+        }
+
+        XmlTag rootTag = myElement.getParent().getParentTag();
+        while (rootTag != null && !"fix".equalsIgnoreCase(rootTag.getName())) {
+            rootTag = rootTag.getParentTag();
+        }
+        if (rootTag == null) {
+            return null;
+        }
+
+        XmlTag fieldsTag = rootTag.findFirstSubTag("fields");
+        if (fieldsTag == null) {
+            return null;
+        }
+
+        for (XmlTag fieldTag : fieldsTag.findSubTags("field")) {
+            String name = fieldTag.getAttributeValue("name");
+            if (fieldName.equals(name)) {
+                XmlAttribute nameAttribute = fieldTag.getAttribute("name");
+                return nameAttribute != null ? nameAttribute : fieldTag;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryFieldReference.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryFieldReference.java
@@ -4,24 +4,33 @@ import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReferenceBase;
 import com.intellij.psi.xml.XmlAttribute;
+import com.intellij.psi.xml.XmlAttributeValue;
 import com.intellij.psi.xml.XmlTag;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class FixDictionaryFieldReference extends PsiReferenceBase<XmlAttribute> {
+public class FixDictionaryFieldReference extends PsiReferenceBase<XmlAttributeValue> {
 
-    public FixDictionaryFieldReference(@NotNull XmlAttribute element, @NotNull TextRange rangeInElement) {
+    public FixDictionaryFieldReference(@NotNull XmlAttributeValue element, @NotNull TextRange rangeInElement) {
         super(element, rangeInElement);
     }
 
     @Override
     public @Nullable PsiElement resolve() {
-        String fieldName = myElement.getValue();
+        PsiElement parent = myElement.getParent();
+        if (!(parent instanceof XmlAttribute attribute)) {
+            return null;
+        }
+
+        String fieldName = attribute.getValue();
         if (fieldName == null || fieldName.isBlank()) {
             return null;
         }
 
-        XmlTag rootTag = myElement.getParent().getParentTag();
+        if (attribute.getParent() == null) {
+            return null;
+        }
+        XmlTag rootTag = attribute.getParent().getParentTag();
         while (rootTag != null && !"fix".equalsIgnoreCase(rootTag.getName())) {
             rootTag = rootTag.getParentTag();
         }

--- a/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryGotoDeclarationHandler.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryGotoDeclarationHandler.java
@@ -21,6 +21,15 @@ public class FixDictionaryGotoDeclarationHandler extends GotoDeclarationHandlerB
     public @Nullable PsiElement getGotoDeclarationTarget(@Nullable PsiElement sourceElement, @NotNull Editor editor) {
         LOG.warn("FixDictionaryGotoDeclarationHandler invoked at offset=" + editor.getCaretModel().getOffset()
                 + ", source=" + (sourceElement == null ? "null" : sourceElement.getClass().getSimpleName()));
+        XmlTag caretFieldTag = findFieldTagAtCaret(editor);
+        if (caretFieldTag != null) {
+            PsiElement resolvedFromTag = resolveFromFieldTag(caretFieldTag);
+            if (resolvedFromTag != null) {
+                LOG.warn("Resolved goto declaration target from caret field tag fallback.");
+                return resolvedFromTag;
+            }
+        }
+
         PsiElement lookupElement = normalizeSourceElement(sourceElement, editor);
         XmlAttributeValue attributeValue = findAttributeValue(lookupElement);
         if (attributeValue == null) {
@@ -51,41 +60,7 @@ public class FixDictionaryGotoDeclarationHandler extends GotoDeclarationHandlerB
         if (!"field".equals(fieldRefTag.getName())) {
             return null;
         }
-        XmlTag containerTag = fieldRefTag.getParentTag();
-        if (containerTag == null || (!"message".equals(containerTag.getName()) && !"group".equals(containerTag.getName()))) {
-            return null;
-        }
-
-        String fieldName = attribute.getValue();
-        if (fieldName == null || fieldName.isBlank()) {
-            return null;
-        }
-        String fileText = attribute.getContainingFile().getText();
-        if (!FixDictionaryXmlUtil.isFixDictionaryText(fileText)) {
-            return null;
-        }
-
-        XmlTag rootTag = containerTag;
-        while (rootTag != null && !"fix".equalsIgnoreCase(rootTag.getName())) {
-            rootTag = rootTag.getParentTag();
-        }
-        if (rootTag == null) {
-            return null;
-        }
-
-        XmlTag fieldsTag = rootTag.findFirstSubTag("fields");
-        if (fieldsTag == null) {
-            return null;
-        }
-        for (XmlTag fieldTag : fieldsTag.findSubTags("field")) {
-            if (fieldName.equals(fieldTag.getAttributeValue("name"))) {
-                XmlAttribute targetNameAttribute = fieldTag.getAttribute("name");
-                LOG.warn("Resolved goto declaration target for field '" + fieldName + "'.");
-                return targetNameAttribute != null ? targetNameAttribute : fieldTag;
-            }
-        }
-        LOG.warn("No declaration target found for field '" + fieldName + "'.");
-        return null;
+        return resolveFromFieldTag(fieldRefTag);
     }
 
     @Override
@@ -149,9 +124,39 @@ public class FixDictionaryGotoDeclarationHandler extends GotoDeclarationHandlerB
             return null;
         }
         XmlTag parent = tag.getParentTag();
-        if (parent == null || (!"message".equals(parent.getName()) && !"group".equals(parent.getName()))) {
+        if (parent == null || "fields".equals(parent.getName())) {
             return null;
         }
         return tag;
+    }
+
+    private PsiElement resolveFromFieldTag(XmlTag fieldRefTag) {
+        String fieldName = fieldRefTag.getAttributeValue("name");
+        if (fieldName == null || fieldName.isBlank()) {
+            return null;
+        }
+        if (!FixDictionaryXmlUtil.isFixDictionaryText(fieldRefTag.getContainingFile().getText())) {
+            return null;
+        }
+        XmlTag rootTag = fieldRefTag;
+        while (rootTag != null && !"fix".equalsIgnoreCase(rootTag.getName())) {
+            rootTag = rootTag.getParentTag();
+        }
+        if (rootTag == null) {
+            return null;
+        }
+        XmlTag fieldsTag = rootTag.findFirstSubTag("fields");
+        if (fieldsTag == null) {
+            return null;
+        }
+        for (XmlTag fieldTag : fieldsTag.findSubTags("field")) {
+            if (fieldName.equals(fieldTag.getAttributeValue("name"))) {
+                XmlAttribute targetNameAttribute = fieldTag.getAttribute("name");
+                LOG.warn("Resolved goto declaration target for field '" + fieldName + "'.");
+                return targetNameAttribute != null ? targetNameAttribute : fieldTag;
+            }
+        }
+        LOG.warn("No declaration target found for field '" + fieldName + "'.");
+        return null;
     }
 }

--- a/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryGotoDeclarationHandler.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryGotoDeclarationHandler.java
@@ -1,0 +1,72 @@
+package com.rannett.fixplugin.dictionary;
+
+import com.intellij.codeInsight.navigation.actions.GotoDeclarationHandlerBase;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.xml.XmlAttribute;
+import com.intellij.psi.xml.XmlAttributeValue;
+import com.intellij.psi.xml.XmlTag;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class FixDictionaryGotoDeclarationHandler extends GotoDeclarationHandlerBase {
+    @Override
+    public @Nullable PsiElement getGotoDeclarationTarget(@Nullable PsiElement sourceElement, @NotNull Editor editor) {
+        if (!(sourceElement instanceof XmlAttributeValue attributeValue)) {
+            return null;
+        }
+        if (!(attributeValue.getParent() instanceof XmlAttribute attribute)) {
+            return null;
+        }
+        if (!"name".equals(attribute.getName())) {
+            return null;
+        }
+        if (attribute.getParent() == null || attribute.getParent().getParentTag() == null) {
+            return null;
+        }
+
+        XmlTag fieldRefTag = attribute.getParent().getParentTag();
+        if (!"field".equals(fieldRefTag.getName())) {
+            return null;
+        }
+        XmlTag containerTag = fieldRefTag.getParentTag();
+        if (containerTag == null || (!"message".equals(containerTag.getName()) && !"group".equals(containerTag.getName()))) {
+            return null;
+        }
+
+        String fieldName = attribute.getValue();
+        if (fieldName == null || fieldName.isBlank()) {
+            return null;
+        }
+        String fileText = attribute.getContainingFile().getText();
+        if (!FixDictionaryXmlUtil.isFixDictionaryText(fileText)) {
+            return null;
+        }
+
+        XmlTag rootTag = containerTag;
+        while (rootTag != null && !"fix".equalsIgnoreCase(rootTag.getName())) {
+            rootTag = rootTag.getParentTag();
+        }
+        if (rootTag == null) {
+            return null;
+        }
+
+        XmlTag fieldsTag = rootTag.findFirstSubTag("fields");
+        if (fieldsTag == null) {
+            return null;
+        }
+        for (XmlTag fieldTag : fieldsTag.findSubTags("field")) {
+            if (fieldName.equals(fieldTag.getAttributeValue("name"))) {
+                XmlAttribute targetNameAttribute = fieldTag.getAttribute("name");
+                return targetNameAttribute != null ? targetNameAttribute.getValueElement() : fieldTag;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public @Nullable String getActionText(DataContext context) {
+        return null;
+    }
+}

--- a/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryGotoDeclarationHandler.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryGotoDeclarationHandler.java
@@ -13,7 +13,8 @@ import org.jetbrains.annotations.Nullable;
 public class FixDictionaryGotoDeclarationHandler extends GotoDeclarationHandlerBase {
     @Override
     public @Nullable PsiElement getGotoDeclarationTarget(@Nullable PsiElement sourceElement, @NotNull Editor editor) {
-        if (!(sourceElement instanceof XmlAttributeValue attributeValue)) {
+        XmlAttributeValue attributeValue = findAttributeValue(sourceElement);
+        if (attributeValue == null) {
             return null;
         }
         if (!(attributeValue.getParent() instanceof XmlAttribute attribute)) {
@@ -67,6 +68,17 @@ public class FixDictionaryGotoDeclarationHandler extends GotoDeclarationHandlerB
 
     @Override
     public @Nullable String getActionText(DataContext context) {
+        return null;
+    }
+
+    private XmlAttributeValue findAttributeValue(PsiElement sourceElement) {
+        PsiElement current = sourceElement;
+        while (current != null) {
+            if (current instanceof XmlAttributeValue value) {
+                return value;
+            }
+            current = current.getParent();
+        }
         return null;
     }
 }

--- a/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryGotoDeclarationHandler.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryGotoDeclarationHandler.java
@@ -16,9 +16,9 @@ import org.jetbrains.annotations.Nullable;
 public class FixDictionaryGotoDeclarationHandler extends GotoDeclarationHandlerBase {
     @Override
     public @Nullable PsiElement getGotoDeclarationTarget(@Nullable PsiElement sourceElement, @NotNull Editor editor) {
-        XmlTag caretFieldTag = findFieldTagAtCaret(editor);
-        if (caretFieldTag != null) {
-            PsiElement resolvedFromTag = resolveFromFieldTag(caretFieldTag);
+        XmlTag caretRefTag = findReferenceTagAtCaret(editor);
+        if (caretRefTag != null) {
+            PsiElement resolvedFromTag = resolveFromReferenceTag(caretRefTag);
             if (resolvedFromTag != null) {
                 return resolvedFromTag;
             }
@@ -27,7 +27,7 @@ public class FixDictionaryGotoDeclarationHandler extends GotoDeclarationHandlerB
         PsiElement lookupElement = normalizeSourceElement(sourceElement, editor);
         XmlAttributeValue attributeValue = findAttributeValue(lookupElement);
         if (attributeValue == null) {
-            XmlTag fieldTag = findFieldTagAtCaret(editor);
+            XmlTag fieldTag = findReferenceTagAtCaret(editor);
             if (fieldTag != null) {
                 XmlAttribute fieldNameAttribute = fieldTag.getAttribute("name");
                 if (fieldNameAttribute != null && fieldNameAttribute.getValueElement() != null) {
@@ -49,10 +49,10 @@ public class FixDictionaryGotoDeclarationHandler extends GotoDeclarationHandlerB
         }
 
         XmlTag fieldRefTag = attribute.getParent().getParentTag();
-        if (!"field".equals(fieldRefTag.getName())) {
+        if (!"field".equals(fieldRefTag.getName()) && !"component".equals(fieldRefTag.getName())) {
             return null;
         }
-        return resolveFromFieldTag(fieldRefTag);
+        return resolveFromReferenceTag(fieldRefTag);
     }
 
     @Override
@@ -97,7 +97,7 @@ public class FixDictionaryGotoDeclarationHandler extends GotoDeclarationHandlerB
         return psiFile.findElementAt(Math.max(0, Math.min(offset, Math.max(textLength - 1, 0))));
     }
 
-    private XmlTag findFieldTagAtCaret(Editor editor) {
+    private XmlTag findReferenceTagAtCaret(Editor editor) {
         if (editor.getProject() == null) {
             return null;
         }
@@ -112,7 +112,7 @@ public class FixDictionaryGotoDeclarationHandler extends GotoDeclarationHandlerB
             PsiElement left = psiFile.findElementAt(offset - 1);
             tag = PsiTreeUtil.getParentOfType(left, XmlTag.class, false);
         }
-        if (tag == null || !"field".equals(tag.getName())) {
+        if (tag == null || (!"field".equals(tag.getName()) && !"component".equals(tag.getName()))) {
             return null;
         }
         XmlTag parent = tag.getParentTag();
@@ -122,7 +122,7 @@ public class FixDictionaryGotoDeclarationHandler extends GotoDeclarationHandlerB
         return tag;
     }
 
-    private PsiElement resolveFromFieldTag(XmlTag fieldRefTag) {
+    private PsiElement resolveFromReferenceTag(XmlTag fieldRefTag) {
         String fieldName = fieldRefTag.getAttributeValue("name");
         if (fieldName == null || fieldName.isBlank()) {
             return null;
@@ -137,14 +137,28 @@ public class FixDictionaryGotoDeclarationHandler extends GotoDeclarationHandlerB
         if (rootTag == null) {
             return null;
         }
-        XmlTag fieldsTag = rootTag.findFirstSubTag("fields");
-        if (fieldsTag == null) {
-            return null;
+        if ("field".equals(fieldRefTag.getName())) {
+            XmlTag fieldsTag = rootTag.findFirstSubTag("fields");
+            if (fieldsTag == null) {
+                return null;
+            }
+            for (XmlTag fieldTag : fieldsTag.findSubTags("field")) {
+                if (fieldName.equals(fieldTag.getAttributeValue("name"))) {
+                    XmlAttribute targetNameAttribute = fieldTag.getAttribute("name");
+                    return targetNameAttribute != null ? targetNameAttribute : fieldTag;
+                }
+            }
         }
-        for (XmlTag fieldTag : fieldsTag.findSubTags("field")) {
-            if (fieldName.equals(fieldTag.getAttributeValue("name"))) {
-                XmlAttribute targetNameAttribute = fieldTag.getAttribute("name");
-                return targetNameAttribute != null ? targetNameAttribute : fieldTag;
+        if ("component".equals(fieldRefTag.getName())) {
+            XmlTag componentsTag = rootTag.findFirstSubTag("components");
+            if (componentsTag == null) {
+                return null;
+            }
+            for (XmlTag componentTag : componentsTag.findSubTags("component")) {
+                if (fieldName.equals(componentTag.getAttributeValue("name"))) {
+                    XmlAttribute targetNameAttribute = componentTag.getAttribute("name");
+                    return targetNameAttribute != null ? targetNameAttribute : componentTag;
+                }
             }
         }
         return null;

--- a/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryGotoDeclarationHandler.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryGotoDeclarationHandler.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.psi.xml.XmlAttribute;
 import com.intellij.psi.xml.XmlAttributeValue;
 import com.intellij.psi.xml.XmlTag;
@@ -23,8 +24,18 @@ public class FixDictionaryGotoDeclarationHandler extends GotoDeclarationHandlerB
         PsiElement lookupElement = normalizeSourceElement(sourceElement, editor);
         XmlAttributeValue attributeValue = findAttributeValue(lookupElement);
         if (attributeValue == null) {
-            LOG.warn("No XmlAttributeValue parent found for goto declaration.");
-            return null;
+            XmlTag fieldTag = findFieldTagAtCaret(editor);
+            if (fieldTag != null) {
+                XmlAttribute fieldNameAttribute = fieldTag.getAttribute("name");
+                if (fieldNameAttribute != null && fieldNameAttribute.getValueElement() != null) {
+                    attributeValue = fieldNameAttribute.getValueElement();
+                    LOG.warn("Recovered XmlAttributeValue via XmlTag fallback.");
+                }
+            }
+            if (attributeValue == null) {
+                LOG.warn("No XmlAttributeValue parent found for goto declaration.");
+                return null;
+            }
         }
         if (!(attributeValue.getParent() instanceof XmlAttribute attribute)) {
             return null;
@@ -117,5 +128,30 @@ public class FixDictionaryGotoDeclarationHandler extends GotoDeclarationHandlerB
             }
         }
         return psiFile.findElementAt(Math.max(0, Math.min(offset, Math.max(textLength - 1, 0))));
+    }
+
+    private XmlTag findFieldTagAtCaret(Editor editor) {
+        if (editor.getProject() == null) {
+            return null;
+        }
+        PsiFile psiFile = com.intellij.psi.PsiDocumentManager.getInstance(editor.getProject()).getPsiFile(editor.getDocument());
+        if (psiFile == null) {
+            return null;
+        }
+        int offset = editor.getCaretModel().getOffset();
+        PsiElement current = psiFile.findElementAt(offset);
+        XmlTag tag = PsiTreeUtil.getParentOfType(current, XmlTag.class, false);
+        if (tag == null && offset > 0) {
+            PsiElement left = psiFile.findElementAt(offset - 1);
+            tag = PsiTreeUtil.getParentOfType(left, XmlTag.class, false);
+        }
+        if (tag == null || !"field".equals(tag.getName())) {
+            return null;
+        }
+        XmlTag parent = tag.getParentTag();
+        if (parent == null || (!"message".equals(parent.getName()) && !"group".equals(parent.getName()))) {
+            return null;
+        }
+        return tag;
     }
 }

--- a/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryGotoDeclarationHandler.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryGotoDeclarationHandler.java
@@ -4,7 +4,6 @@ import com.intellij.codeInsight.navigation.actions.GotoDeclarationHandlerBase;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -15,17 +14,12 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class FixDictionaryGotoDeclarationHandler extends GotoDeclarationHandlerBase {
-    private static final Logger LOG = Logger.getInstance(FixDictionaryGotoDeclarationHandler.class);
-
     @Override
     public @Nullable PsiElement getGotoDeclarationTarget(@Nullable PsiElement sourceElement, @NotNull Editor editor) {
-        LOG.warn("FixDictionaryGotoDeclarationHandler invoked at offset=" + editor.getCaretModel().getOffset()
-                + ", source=" + (sourceElement == null ? "null" : sourceElement.getClass().getSimpleName()));
         XmlTag caretFieldTag = findFieldTagAtCaret(editor);
         if (caretFieldTag != null) {
             PsiElement resolvedFromTag = resolveFromFieldTag(caretFieldTag);
             if (resolvedFromTag != null) {
-                LOG.warn("Resolved goto declaration target from caret field tag fallback.");
                 return resolvedFromTag;
             }
         }
@@ -38,11 +32,9 @@ public class FixDictionaryGotoDeclarationHandler extends GotoDeclarationHandlerB
                 XmlAttribute fieldNameAttribute = fieldTag.getAttribute("name");
                 if (fieldNameAttribute != null && fieldNameAttribute.getValueElement() != null) {
                     attributeValue = fieldNameAttribute.getValueElement();
-                    LOG.warn("Recovered XmlAttributeValue via XmlTag fallback.");
                 }
             }
             if (attributeValue == null) {
-                LOG.warn("No XmlAttributeValue parent found for goto declaration.");
                 return null;
             }
         }
@@ -152,11 +144,9 @@ public class FixDictionaryGotoDeclarationHandler extends GotoDeclarationHandlerB
         for (XmlTag fieldTag : fieldsTag.findSubTags("field")) {
             if (fieldName.equals(fieldTag.getAttributeValue("name"))) {
                 XmlAttribute targetNameAttribute = fieldTag.getAttribute("name");
-                LOG.warn("Resolved goto declaration target for field '" + fieldName + "'.");
                 return targetNameAttribute != null ? targetNameAttribute : fieldTag;
             }
         }
-        LOG.warn("No declaration target found for field '" + fieldName + "'.");
         return null;
     }
 }

--- a/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryGotoDeclarationHandler.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryGotoDeclarationHandler.java
@@ -3,6 +3,7 @@ package com.rannett.fixplugin.dictionary;
 import com.intellij.codeInsight.navigation.actions.GotoDeclarationHandlerBase;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.xml.XmlAttribute;
 import com.intellij.psi.xml.XmlAttributeValue;
@@ -11,10 +12,15 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class FixDictionaryGotoDeclarationHandler extends GotoDeclarationHandlerBase {
+    private static final Logger LOG = Logger.getInstance(FixDictionaryGotoDeclarationHandler.class);
+
     @Override
     public @Nullable PsiElement getGotoDeclarationTarget(@Nullable PsiElement sourceElement, @NotNull Editor editor) {
+        LOG.warn("FixDictionaryGotoDeclarationHandler invoked at offset=" + editor.getCaretModel().getOffset()
+                + ", source=" + (sourceElement == null ? "null" : sourceElement.getClass().getSimpleName()));
         XmlAttributeValue attributeValue = findAttributeValue(sourceElement);
         if (attributeValue == null) {
+            LOG.warn("No XmlAttributeValue parent found for goto declaration.");
             return null;
         }
         if (!(attributeValue.getParent() instanceof XmlAttribute attribute)) {
@@ -60,9 +66,11 @@ public class FixDictionaryGotoDeclarationHandler extends GotoDeclarationHandlerB
         for (XmlTag fieldTag : fieldsTag.findSubTags("field")) {
             if (fieldName.equals(fieldTag.getAttributeValue("name"))) {
                 XmlAttribute targetNameAttribute = fieldTag.getAttribute("name");
-                return targetNameAttribute != null ? targetNameAttribute.getValueElement() : fieldTag;
+                LOG.warn("Resolved goto declaration target for field '" + fieldName + "'.");
+                return targetNameAttribute != null ? targetNameAttribute : fieldTag;
             }
         }
+        LOG.warn("No declaration target found for field '" + fieldName + "'.");
         return null;
     }
 

--- a/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryGotoDeclarationHandler.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryGotoDeclarationHandler.java
@@ -56,7 +56,7 @@ public class FixDictionaryGotoDeclarationHandler extends GotoDeclarationHandlerB
     }
 
     @Override
-    public @Nullable String getActionText(DataContext context) {
+    public @Nullable String getActionText(@NotNull DataContext context) {
         return null;
     }
 

--- a/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryGotoDeclarationHandler.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryGotoDeclarationHandler.java
@@ -2,9 +2,11 @@ package com.rannett.fixplugin.dictionary;
 
 import com.intellij.codeInsight.navigation.actions.GotoDeclarationHandlerBase;
 import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
 import com.intellij.psi.xml.XmlAttribute;
 import com.intellij.psi.xml.XmlAttributeValue;
 import com.intellij.psi.xml.XmlTag;
@@ -18,7 +20,8 @@ public class FixDictionaryGotoDeclarationHandler extends GotoDeclarationHandlerB
     public @Nullable PsiElement getGotoDeclarationTarget(@Nullable PsiElement sourceElement, @NotNull Editor editor) {
         LOG.warn("FixDictionaryGotoDeclarationHandler invoked at offset=" + editor.getCaretModel().getOffset()
                 + ", source=" + (sourceElement == null ? "null" : sourceElement.getClass().getSimpleName()));
-        XmlAttributeValue attributeValue = findAttributeValue(sourceElement);
+        PsiElement lookupElement = normalizeSourceElement(sourceElement, editor);
+        XmlAttributeValue attributeValue = findAttributeValue(lookupElement);
         if (attributeValue == null) {
             LOG.warn("No XmlAttributeValue parent found for goto declaration.");
             return null;
@@ -88,5 +91,31 @@ public class FixDictionaryGotoDeclarationHandler extends GotoDeclarationHandlerB
             current = current.getParent();
         }
         return null;
+    }
+
+    private PsiElement normalizeSourceElement(PsiElement sourceElement, Editor editor) {
+        if (sourceElement != null) {
+            return sourceElement;
+        }
+        PsiFile psiFile = editor.getProject() == null ? null : com.intellij.psi.PsiDocumentManager.getInstance(editor.getProject()).getPsiFile(editor.getDocument());
+        if (psiFile == null) {
+            return null;
+        }
+        int offset = editor.getCaretModel().getOffset();
+        Document document = editor.getDocument();
+        int textLength = document.getTextLength();
+        if (offset > 0 && offset <= textLength) {
+            PsiElement left = psiFile.findElementAt(offset - 1);
+            if (left != null) {
+                return left;
+            }
+        }
+        if (offset < textLength) {
+            PsiElement right = psiFile.findElementAt(offset);
+            if (right != null) {
+                return right;
+            }
+        }
+        return psiFile.findElementAt(Math.max(0, Math.min(offset, Math.max(textLength - 1, 0))));
     }
 }

--- a/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryXmlReferenceContributor.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryXmlReferenceContributor.java
@@ -26,14 +26,15 @@ public class FixDictionaryXmlReferenceContributor extends PsiReferenceContributo
                         if (!"name".equals(attribute.getName())) {
                             return PsiReference.EMPTY_ARRAY;
                         }
-                        if (attribute.getParent() == null || attribute.getParent().getParentTag() == null) {
+                        if (attribute.getParent() == null) {
                             return PsiReference.EMPTY_ARRAY;
                         }
-                        if (!"field".equals(attribute.getParent().getParentTag().getName())) {
+                        com.intellij.psi.xml.XmlTag referenceTag = attribute.getParent().getParentTag();
+                        if (referenceTag == null || !"field".equals(referenceTag.getName())) {
                             return PsiReference.EMPTY_ARRAY;
                         }
-                        if (attribute.getParent().getParentTag().getParentTag() == null ||
-                                !"message".equals(attribute.getParent().getParentTag().getParentTag().getName())) {
+                        com.intellij.psi.xml.XmlTag containerTag = referenceTag.getParentTag();
+                        if (containerTag == null || !"message".equals(containerTag.getName())) {
                             return PsiReference.EMPTY_ARRAY;
                         }
                         if (!FixDictionaryXmlUtil.isFixDictionaryText(attribute.getContainingFile().getText())) {

--- a/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryXmlReferenceContributor.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryXmlReferenceContributor.java
@@ -1,0 +1,52 @@
+package com.rannett.fixplugin.dictionary;
+
+import com.intellij.patterns.PlatformPatterns;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.PsiReferenceContributor;
+import com.intellij.psi.PsiReferenceRegistrar;
+import com.intellij.psi.xml.XmlAttribute;
+import com.intellij.util.ProcessingContext;
+import org.jetbrains.annotations.NotNull;
+
+public class FixDictionaryXmlReferenceContributor extends PsiReferenceContributor {
+    @Override
+    public void registerReferenceProviders(@NotNull PsiReferenceRegistrar registrar) {
+        registrar.registerReferenceProvider(
+                PlatformPatterns.psiElement(XmlAttribute.class),
+                new com.intellij.psi.PsiReferenceProvider() {
+                    @Override
+                    public PsiReference @NotNull [] getReferencesByElement(@NotNull com.intellij.psi.PsiElement element,
+                                                                           @NotNull ProcessingContext context) {
+                        XmlAttribute attribute = (XmlAttribute) element;
+                        if (!"name".equals(attribute.getName())) {
+                            return PsiReference.EMPTY_ARRAY;
+                        }
+                        if (attribute.getParent() == null || attribute.getParent().getParentTag() == null) {
+                            return PsiReference.EMPTY_ARRAY;
+                        }
+                        if (!"field".equals(attribute.getParent().getParentTag().getName())) {
+                            return PsiReference.EMPTY_ARRAY;
+                        }
+                        if (attribute.getParent().getParentTag().getParentTag() == null ||
+                                !"message".equals(attribute.getParent().getParentTag().getParentTag().getName())) {
+                            return PsiReference.EMPTY_ARRAY;
+                        }
+                        if (!FixDictionaryXmlUtil.isFixDictionaryText(attribute.getContainingFile().getText())) {
+                            return PsiReference.EMPTY_ARRAY;
+                        }
+
+                        String value = attribute.getValue();
+                        if (value == null) {
+                            return PsiReference.EMPTY_ARRAY;
+                        }
+                        int startOffset = attribute.getValueElement() != null
+                                ? attribute.getValueElement().getTextRange().getStartOffset() - attribute.getTextRange().getStartOffset()
+                                : 0;
+                        return new PsiReference[]{
+                                new FixDictionaryFieldReference(attribute, new com.intellij.openapi.util.TextRange(startOffset, startOffset + value.length()))
+                        };
+                    }
+                }
+        );
+    }
+}

--- a/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryXmlReferenceContributor.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryXmlReferenceContributor.java
@@ -1,10 +1,12 @@
 package com.rannett.fixplugin.dictionary;
 
 import com.intellij.patterns.PlatformPatterns;
+import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.PsiReferenceContributor;
 import com.intellij.psi.PsiReferenceRegistrar;
 import com.intellij.psi.xml.XmlAttribute;
+import com.intellij.psi.xml.XmlAttributeValue;
 import com.intellij.util.ProcessingContext;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,12 +14,15 @@ public class FixDictionaryXmlReferenceContributor extends PsiReferenceContributo
     @Override
     public void registerReferenceProviders(@NotNull PsiReferenceRegistrar registrar) {
         registrar.registerReferenceProvider(
-                PlatformPatterns.psiElement(XmlAttribute.class),
+                PlatformPatterns.psiElement(XmlAttributeValue.class),
                 new com.intellij.psi.PsiReferenceProvider() {
                     @Override
                     public PsiReference @NotNull [] getReferencesByElement(@NotNull com.intellij.psi.PsiElement element,
                                                                            @NotNull ProcessingContext context) {
-                        XmlAttribute attribute = (XmlAttribute) element;
+                        XmlAttributeValue attributeValue = (XmlAttributeValue) element;
+                        if (!(attributeValue.getParent() instanceof XmlAttribute attribute)) {
+                            return PsiReference.EMPTY_ARRAY;
+                        }
                         if (!"name".equals(attribute.getName())) {
                             return PsiReference.EMPTY_ARRAY;
                         }
@@ -39,11 +44,8 @@ public class FixDictionaryXmlReferenceContributor extends PsiReferenceContributo
                         if (value == null) {
                             return PsiReference.EMPTY_ARRAY;
                         }
-                        int startOffset = attribute.getValueElement() != null
-                                ? attribute.getValueElement().getTextRange().getStartOffset() - attribute.getTextRange().getStartOffset()
-                                : 0;
                         return new PsiReference[]{
-                                new FixDictionaryFieldReference(attribute, new com.intellij.openapi.util.TextRange(startOffset, startOffset + value.length()))
+                                new FixDictionaryFieldReference(attributeValue, TextRange.from(1, value.length()))
                         };
                     }
                 }

--- a/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryXmlUtil.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryXmlUtil.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.regex.Pattern;
 
 public final class FixDictionaryXmlUtil {
-    private static final Pattern ROOT_PATTERN = Pattern.compile("<\\s*fix(?:\\s|>)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern ROOT_PATTERN = Pattern.compile("^\\s*(?:<\\?xml[^>]*>\\s*)?<\\s*fix(?:\\s|>)", Pattern.CASE_INSENSITIVE);
 
     private FixDictionaryXmlUtil() {
     }

--- a/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryXmlUtil.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryXmlUtil.java
@@ -1,0 +1,41 @@
+package com.rannett.fixplugin.dictionary;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.regex.Pattern;
+
+public final class FixDictionaryXmlUtil {
+    private static final Pattern ROOT_PATTERN = Pattern.compile("<\\s*fix(?:\\s|>)", Pattern.CASE_INSENSITIVE);
+
+    private FixDictionaryXmlUtil() {
+    }
+
+    public static boolean isFixDictionaryFile(@NotNull VirtualFile file) {
+        if (!"xml".equalsIgnoreCase(file.getExtension())) {
+            return false;
+        }
+        Document document = FileDocumentManager.getInstance().getDocument(file);
+        if (document == null) {
+            return false;
+        }
+        return isFixDictionaryText(document.getText());
+    }
+
+    public static boolean isFixDictionaryText(@NotNull String text) {
+        if (!ROOT_PATTERN.matcher(text).find()) {
+            return false;
+        }
+
+        long sectionsFound = Pattern.compile("<\\s*(messages|fields|components|header|trailer)(?:\\s|>)", Pattern.CASE_INSENSITIVE)
+                .matcher(text)
+                .results()
+                .map(matchResult -> matchResult.group(1).toLowerCase())
+                .distinct()
+                .count();
+
+        return sectionsFound >= 2;
+    }
+}

--- a/src/main/java/com/rannett/fixplugin/dictionary/GoToFixFieldDefinitionAction.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/GoToFixFieldDefinitionAction.java
@@ -46,7 +46,7 @@ public class GoToFixFieldDefinitionAction extends AnAction {
         }
 
         PsiFile psiFile = event.getData(CommonDataKeys.PSI_FILE);
-        if (psiFile == null && project != null) {
+        if (psiFile == null) {
             psiFile = PsiDocumentManager.getInstance(project).getPsiFile(editor.getDocument());
         }
         if (psiFile == null) {

--- a/src/main/java/com/rannett/fixplugin/dictionary/GoToFixFieldDefinitionAction.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/GoToFixFieldDefinitionAction.java
@@ -7,17 +7,16 @@ import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.navigation.NavigationItem;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.xml.XmlAttribute;
 import com.intellij.psi.xml.XmlAttributeValue;
 import com.intellij.psi.xml.XmlTag;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.jetbrains.annotations.NotNull;
 
 public class GoToFixFieldDefinitionAction extends AnAction {
-    private static final Logger LOG = Logger.getInstance(GoToFixFieldDefinitionAction.class);
-
     @Override
     public void actionPerformed(@NotNull AnActionEvent event) {
         Project project = event.getProject();
@@ -31,14 +30,9 @@ public class GoToFixFieldDefinitionAction extends AnAction {
             return;
         }
         PsiElement sourceElement = psiFile.findElementAt(editor.getCaretModel().getOffset());
-        LOG.warn("GoToFixFieldDefinitionAction invoked at offset " + editor.getCaretModel().getOffset()
-                + " element=" + (sourceElement == null ? "null" : sourceElement.getClass().getSimpleName()));
         PsiElement target = resolveTarget(sourceElement);
         if (target instanceof NavigationItem navigationItem) {
             navigationItem.navigate(true);
-            LOG.warn("Navigated to FIX field definition.");
-        } else {
-            LOG.warn("No FIX field definition target found.");
         }
     }
 
@@ -52,14 +46,16 @@ public class GoToFixFieldDefinitionAction extends AnAction {
         }
 
         PsiFile psiFile = event.getData(CommonDataKeys.PSI_FILE);
+        if (psiFile == null && project != null) {
+            psiFile = PsiDocumentManager.getInstance(project).getPsiFile(editor.getDocument());
+        }
         if (psiFile == null) {
             event.getPresentation().setEnabledAndVisible(false);
             return;
         }
 
-        PsiElement sourceElement = psiFile.findElementAt(editor.getCaretModel().getOffset());
-        PsiElement target = resolveTarget(sourceElement);
-        event.getPresentation().setEnabledAndVisible(target != null);
+        XmlTag fieldTag = findFieldTagAtCaret(psiFile, editor.getCaretModel().getOffset());
+        event.getPresentation().setEnabledAndVisible(fieldTag != null && FixDictionaryXmlUtil.isFixDictionaryText(psiFile.getText()));
     }
 
     @Override
@@ -68,6 +64,13 @@ public class GoToFixFieldDefinitionAction extends AnAction {
     }
 
     private PsiElement resolveTarget(PsiElement sourceElement) {
+        XmlTag tagFallback = PsiTreeUtil.getParentOfType(sourceElement, XmlTag.class);
+        if (tagFallback != null && "field".equals(tagFallback.getName())) {
+            PsiElement resolved = resolveFromFieldTag(tagFallback);
+            if (resolved != null) {
+                return resolved;
+            }
+        }
         XmlAttributeValue attributeValue = findAttributeValue(sourceElement);
         if (attributeValue == null) {
             return null;
@@ -86,17 +89,19 @@ public class GoToFixFieldDefinitionAction extends AnAction {
         if (!"field".equals(fieldRefTag.getName())) {
             return null;
         }
+        return resolveFromFieldTag(fieldRefTag);
+    }
+
+    private PsiElement resolveFromFieldTag(XmlTag fieldRefTag) {
         XmlTag containerTag = fieldRefTag.getParentTag();
         if (containerTag == null || "fields".equals(containerTag.getName())) {
             return null;
         }
-
-        String fieldName = attribute.getValue();
+        String fieldName = fieldRefTag.getAttributeValue("name");
         if (fieldName == null || fieldName.isBlank()) {
             return null;
         }
-
-        if (!FixDictionaryXmlUtil.isFixDictionaryText(attribute.getContainingFile().getText())) {
+        if (!FixDictionaryXmlUtil.isFixDictionaryText(fieldRefTag.getContainingFile().getText())) {
             return null;
         }
 
@@ -120,6 +125,22 @@ public class GoToFixFieldDefinitionAction extends AnAction {
             }
         }
         return null;
+    }
+
+    private XmlTag findFieldTagAtCaret(PsiFile psiFile, int offset) {
+        PsiElement element = psiFile.findElementAt(offset);
+        XmlTag tag = PsiTreeUtil.getParentOfType(element, XmlTag.class);
+        if (tag == null && offset > 0) {
+            tag = PsiTreeUtil.getParentOfType(psiFile.findElementAt(offset - 1), XmlTag.class);
+        }
+        if (tag == null || !"field".equals(tag.getName())) {
+            return null;
+        }
+        XmlTag parent = tag.getParentTag();
+        if (parent == null || "fields".equals(parent.getName())) {
+            return null;
+        }
+        return tag;
     }
 
     private XmlAttributeValue findAttributeValue(PsiElement sourceElement) {

--- a/src/main/java/com/rannett/fixplugin/dictionary/GoToFixFieldDefinitionAction.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/GoToFixFieldDefinitionAction.java
@@ -54,7 +54,7 @@ public class GoToFixFieldDefinitionAction extends AnAction {
             return;
         }
 
-        XmlTag fieldTag = findFieldTagAtCaret(psiFile, editor.getCaretModel().getOffset());
+        XmlTag fieldTag = findReferenceTagAtCaret(psiFile, editor.getCaretModel().getOffset());
         event.getPresentation().setEnabledAndVisible(fieldTag != null && FixDictionaryXmlUtil.isFixDictionaryText(psiFile.getText()));
     }
 
@@ -65,8 +65,8 @@ public class GoToFixFieldDefinitionAction extends AnAction {
 
     private PsiElement resolveTarget(PsiElement sourceElement) {
         XmlTag tagFallback = PsiTreeUtil.getParentOfType(sourceElement, XmlTag.class);
-        if (tagFallback != null && "field".equals(tagFallback.getName())) {
-            PsiElement resolved = resolveFromFieldTag(tagFallback);
+        if (tagFallback != null && ("field".equals(tagFallback.getName()) || "component".equals(tagFallback.getName()))) {
+            PsiElement resolved = resolveFromReferenceTag(tagFallback);
             if (resolved != null) {
                 return resolved;
             }
@@ -86,13 +86,13 @@ public class GoToFixFieldDefinitionAction extends AnAction {
         }
 
         XmlTag fieldRefTag = attribute.getParent().getParentTag();
-        if (!"field".equals(fieldRefTag.getName())) {
+        if (!"field".equals(fieldRefTag.getName()) && !"component".equals(fieldRefTag.getName())) {
             return null;
         }
-        return resolveFromFieldTag(fieldRefTag);
+        return resolveFromReferenceTag(fieldRefTag);
     }
 
-    private PsiElement resolveFromFieldTag(XmlTag fieldRefTag) {
+    private PsiElement resolveFromReferenceTag(XmlTag fieldRefTag) {
         XmlTag containerTag = fieldRefTag.getParentTag();
         if (containerTag == null || "fields".equals(containerTag.getName())) {
             return null;
@@ -113,27 +113,40 @@ public class GoToFixFieldDefinitionAction extends AnAction {
             return null;
         }
 
-        XmlTag fieldsTag = rootTag.findFirstSubTag("fields");
-        if (fieldsTag == null) {
-            return null;
+        if ("field".equals(fieldRefTag.getName())) {
+            XmlTag fieldsTag = rootTag.findFirstSubTag("fields");
+            if (fieldsTag == null) {
+                return null;
+            }
+            for (XmlTag fieldTag : fieldsTag.findSubTags("field")) {
+                if (fieldName.equals(fieldTag.getAttributeValue("name"))) {
+                    XmlAttribute targetNameAttribute = fieldTag.getAttribute("name");
+                    return targetNameAttribute != null ? targetNameAttribute : fieldTag;
+                }
+            }
         }
-
-        for (XmlTag fieldTag : fieldsTag.findSubTags("field")) {
-            if (fieldName.equals(fieldTag.getAttributeValue("name"))) {
-                XmlAttribute targetNameAttribute = fieldTag.getAttribute("name");
-                return targetNameAttribute != null ? targetNameAttribute : fieldTag;
+        if ("component".equals(fieldRefTag.getName())) {
+            XmlTag componentsTag = rootTag.findFirstSubTag("components");
+            if (componentsTag == null) {
+                return null;
+            }
+            for (XmlTag componentTag : componentsTag.findSubTags("component")) {
+                if (fieldName.equals(componentTag.getAttributeValue("name"))) {
+                    XmlAttribute targetNameAttribute = componentTag.getAttribute("name");
+                    return targetNameAttribute != null ? targetNameAttribute : componentTag;
+                }
             }
         }
         return null;
     }
 
-    private XmlTag findFieldTagAtCaret(PsiFile psiFile, int offset) {
+    private XmlTag findReferenceTagAtCaret(PsiFile psiFile, int offset) {
         PsiElement element = psiFile.findElementAt(offset);
         XmlTag tag = PsiTreeUtil.getParentOfType(element, XmlTag.class);
         if (tag == null && offset > 0) {
             tag = PsiTreeUtil.getParentOfType(psiFile.findElementAt(offset - 1), XmlTag.class);
         }
-        if (tag == null || !"field".equals(tag.getName())) {
+        if (tag == null || (!"field".equals(tag.getName()) && !"component".equals(tag.getName()))) {
             return null;
         }
         XmlTag parent = tag.getParentTag();

--- a/src/main/java/com/rannett/fixplugin/dictionary/GoToFixFieldDefinitionAction.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/GoToFixFieldDefinitionAction.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.navigation.NavigationItem;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.xml.XmlAttribute;
@@ -15,6 +16,8 @@ import com.intellij.psi.xml.XmlTag;
 import org.jetbrains.annotations.NotNull;
 
 public class GoToFixFieldDefinitionAction extends AnAction {
+    private static final Logger LOG = Logger.getInstance(GoToFixFieldDefinitionAction.class);
+
     @Override
     public void actionPerformed(@NotNull AnActionEvent event) {
         Project project = event.getProject();
@@ -28,9 +31,14 @@ public class GoToFixFieldDefinitionAction extends AnAction {
             return;
         }
         PsiElement sourceElement = psiFile.findElementAt(editor.getCaretModel().getOffset());
+        LOG.info("GoToFixFieldDefinitionAction invoked at offset " + editor.getCaretModel().getOffset()
+                + " element=" + (sourceElement == null ? "null" : sourceElement.getClass().getSimpleName()));
         PsiElement target = resolveTarget(sourceElement);
         if (target instanceof NavigationItem navigationItem) {
             navigationItem.navigate(true);
+            LOG.info("Navigated to FIX field definition.");
+        } else {
+            LOG.info("No FIX field definition target found.");
         }
     }
 
@@ -60,7 +68,8 @@ public class GoToFixFieldDefinitionAction extends AnAction {
     }
 
     private PsiElement resolveTarget(PsiElement sourceElement) {
-        if (!(sourceElement instanceof XmlAttributeValue attributeValue)) {
+        XmlAttributeValue attributeValue = findAttributeValue(sourceElement);
+        if (attributeValue == null) {
             return null;
         }
         if (!(attributeValue.getParent() instanceof XmlAttribute attribute)) {
@@ -109,6 +118,17 @@ public class GoToFixFieldDefinitionAction extends AnAction {
                 XmlAttribute targetNameAttribute = fieldTag.getAttribute("name");
                 return targetNameAttribute != null ? targetNameAttribute.getValueElement() : fieldTag;
             }
+        }
+        return null;
+    }
+
+    private XmlAttributeValue findAttributeValue(PsiElement sourceElement) {
+        PsiElement cursor = sourceElement;
+        while (cursor != null) {
+            if (cursor instanceof XmlAttributeValue value) {
+                return value;
+            }
+            cursor = cursor.getParent();
         }
         return null;
     }

--- a/src/main/java/com/rannett/fixplugin/dictionary/GoToFixFieldDefinitionAction.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/GoToFixFieldDefinitionAction.java
@@ -1,0 +1,115 @@
+package com.rannett.fixplugin.dictionary;
+
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.navigation.NavigationItem;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.xml.XmlAttribute;
+import com.intellij.psi.xml.XmlAttributeValue;
+import com.intellij.psi.xml.XmlTag;
+import org.jetbrains.annotations.NotNull;
+
+public class GoToFixFieldDefinitionAction extends AnAction {
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent event) {
+        Project project = event.getProject();
+        Editor editor = event.getData(CommonDataKeys.EDITOR);
+        if (project == null || editor == null) {
+            return;
+        }
+
+        PsiFile psiFile = event.getData(CommonDataKeys.PSI_FILE);
+        if (psiFile == null) {
+            return;
+        }
+        PsiElement sourceElement = psiFile.findElementAt(editor.getCaretModel().getOffset());
+        PsiElement target = resolveTarget(sourceElement);
+        if (target instanceof NavigationItem navigationItem) {
+            navigationItem.navigate(true);
+        }
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent event) {
+        Project project = event.getProject();
+        Editor editor = event.getData(CommonDataKeys.EDITOR);
+        if (project == null || editor == null) {
+            event.getPresentation().setEnabledAndVisible(false);
+            return;
+        }
+
+        PsiFile psiFile = event.getData(CommonDataKeys.PSI_FILE);
+        if (psiFile == null) {
+            event.getPresentation().setEnabledAndVisible(false);
+            return;
+        }
+
+        PsiElement sourceElement = psiFile.findElementAt(editor.getCaretModel().getOffset());
+        PsiElement target = resolveTarget(sourceElement);
+        event.getPresentation().setEnabledAndVisible(target != null);
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
+    }
+
+    private PsiElement resolveTarget(PsiElement sourceElement) {
+        if (!(sourceElement instanceof XmlAttributeValue attributeValue)) {
+            return null;
+        }
+        if (!(attributeValue.getParent() instanceof XmlAttribute attribute)) {
+            return null;
+        }
+        if (!"name".equals(attribute.getName())) {
+            return null;
+        }
+        if (attribute.getParent() == null || attribute.getParent().getParentTag() == null) {
+            return null;
+        }
+
+        XmlTag fieldRefTag = attribute.getParent().getParentTag();
+        if (!"field".equals(fieldRefTag.getName())) {
+            return null;
+        }
+        XmlTag containerTag = fieldRefTag.getParentTag();
+        if (containerTag == null || (!"message".equals(containerTag.getName()) && !"group".equals(containerTag.getName()))) {
+            return null;
+        }
+
+        String fieldName = attribute.getValue();
+        if (fieldName == null || fieldName.isBlank()) {
+            return null;
+        }
+
+        if (!FixDictionaryXmlUtil.isFixDictionaryText(attribute.getContainingFile().getText())) {
+            return null;
+        }
+
+        XmlTag rootTag = containerTag;
+        while (rootTag != null && !"fix".equalsIgnoreCase(rootTag.getName())) {
+            rootTag = rootTag.getParentTag();
+        }
+        if (rootTag == null) {
+            return null;
+        }
+
+        XmlTag fieldsTag = rootTag.findFirstSubTag("fields");
+        if (fieldsTag == null) {
+            return null;
+        }
+
+        for (XmlTag fieldTag : fieldsTag.findSubTags("field")) {
+            if (fieldName.equals(fieldTag.getAttributeValue("name"))) {
+                XmlAttribute targetNameAttribute = fieldTag.getAttribute("name");
+                return targetNameAttribute != null ? targetNameAttribute.getValueElement() : fieldTag;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/rannett/fixplugin/dictionary/GoToFixFieldDefinitionAction.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/GoToFixFieldDefinitionAction.java
@@ -31,14 +31,14 @@ public class GoToFixFieldDefinitionAction extends AnAction {
             return;
         }
         PsiElement sourceElement = psiFile.findElementAt(editor.getCaretModel().getOffset());
-        LOG.info("GoToFixFieldDefinitionAction invoked at offset " + editor.getCaretModel().getOffset()
+        LOG.warn("GoToFixFieldDefinitionAction invoked at offset " + editor.getCaretModel().getOffset()
                 + " element=" + (sourceElement == null ? "null" : sourceElement.getClass().getSimpleName()));
         PsiElement target = resolveTarget(sourceElement);
         if (target instanceof NavigationItem navigationItem) {
             navigationItem.navigate(true);
-            LOG.info("Navigated to FIX field definition.");
+            LOG.warn("Navigated to FIX field definition.");
         } else {
-            LOG.info("No FIX field definition target found.");
+            LOG.warn("No FIX field definition target found.");
         }
     }
 
@@ -116,7 +116,7 @@ public class GoToFixFieldDefinitionAction extends AnAction {
         for (XmlTag fieldTag : fieldsTag.findSubTags("field")) {
             if (fieldName.equals(fieldTag.getAttributeValue("name"))) {
                 XmlAttribute targetNameAttribute = fieldTag.getAttribute("name");
-                return targetNameAttribute != null ? targetNameAttribute.getValueElement() : fieldTag;
+                return targetNameAttribute != null ? targetNameAttribute : fieldTag;
             }
         }
         return null;

--- a/src/main/java/com/rannett/fixplugin/dictionary/GoToFixFieldDefinitionAction.java
+++ b/src/main/java/com/rannett/fixplugin/dictionary/GoToFixFieldDefinitionAction.java
@@ -87,7 +87,7 @@ public class GoToFixFieldDefinitionAction extends AnAction {
             return null;
         }
         XmlTag containerTag = fieldRefTag.getParentTag();
-        if (containerTag == null || (!"message".equals(containerTag.getName()) && !"group".equals(containerTag.getName()))) {
+        if (containerTag == null || "fields".equals(containerTag.getName())) {
             return null;
         }
 

--- a/src/main/java/com/rannett/fixplugin/ui/FixDictionaryFileEditor.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixDictionaryFileEditor.java
@@ -9,23 +9,33 @@ import com.intellij.openapi.fileEditor.impl.text.TextEditorProvider;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.UserDataHolderBase;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.util.ui.JBUI;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.swing.JPanel;
 import javax.swing.JComponent;
+import java.awt.BorderLayout;
 
 public class FixDictionaryFileEditor extends UserDataHolderBase implements FileEditor {
     private final TextEditor delegate;
     private final VirtualFile file;
+    private final JPanel panel;
 
     public FixDictionaryFileEditor(@NotNull Project project, @NotNull VirtualFile file) {
         this.file = file;
         this.delegate = (TextEditor) TextEditorProvider.getInstance().createEditor(project, file);
+        this.panel = new JPanel(new BorderLayout());
+        JBLabel header = new JBLabel("FIX Dictionary View");
+        header.setBorder(JBUI.Borders.empty(4, 8));
+        this.panel.add(header, BorderLayout.NORTH);
+        this.panel.add(delegate.getComponent(), BorderLayout.CENTER);
     }
 
     @Override
     public @NotNull JComponent getComponent() {
-        return delegate.getComponent();
+        return panel;
     }
 
     @Override

--- a/src/main/java/com/rannett/fixplugin/ui/FixDictionaryFileEditor.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixDictionaryFileEditor.java
@@ -16,8 +16,10 @@ import javax.swing.JComponent;
 
 public class FixDictionaryFileEditor extends UserDataHolderBase implements FileEditor {
     private final TextEditor delegate;
+    private final VirtualFile file;
 
     public FixDictionaryFileEditor(@NotNull Project project, @NotNull VirtualFile file) {
+        this.file = file;
         this.delegate = (TextEditor) TextEditorProvider.getInstance().createEditor(project, file);
     }
 
@@ -34,6 +36,11 @@ public class FixDictionaryFileEditor extends UserDataHolderBase implements FileE
     @Override
     public @NotNull String getName() {
         return "FIX Dictionary";
+    }
+
+    @Override
+    public @NotNull VirtualFile getFile() {
+        return file;
     }
 
     @Override

--- a/src/main/java/com/rannett/fixplugin/ui/FixDictionaryFileEditor.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixDictionaryFileEditor.java
@@ -27,7 +27,7 @@ public class FixDictionaryFileEditor extends UserDataHolderBase implements FileE
         this.file = file;
         this.delegate = (TextEditor) TextEditorProvider.getInstance().createEditor(project, file);
         this.panel = new JPanel(new BorderLayout());
-        JBLabel header = new JBLabel("FIX Dictionary View");
+        JBLabel header = new JBLabel("Fix dictionary view");
         header.setBorder(JBUI.Borders.empty(4, 8));
         this.panel.add(header, BorderLayout.NORTH);
         this.panel.add(delegate.getComponent(), BorderLayout.CENTER);

--- a/src/main/java/com/rannett/fixplugin/ui/FixDictionaryFileEditor.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixDictionaryFileEditor.java
@@ -1,0 +1,88 @@
+package com.rannett.fixplugin.ui;
+
+import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.fileEditor.FileEditorLocation;
+import com.intellij.openapi.fileEditor.FileEditorState;
+import com.intellij.openapi.fileEditor.FileEditorStateLevel;
+import com.intellij.openapi.fileEditor.TextEditor;
+import com.intellij.openapi.fileEditor.impl.text.TextEditorProvider;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.UserDataHolderBase;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.JComponent;
+
+public class FixDictionaryFileEditor extends UserDataHolderBase implements FileEditor {
+    private final TextEditor delegate;
+
+    public FixDictionaryFileEditor(@NotNull Project project, @NotNull VirtualFile file) {
+        this.delegate = (TextEditor) TextEditorProvider.getInstance().createEditor(project, file);
+    }
+
+    @Override
+    public @NotNull JComponent getComponent() {
+        return delegate.getComponent();
+    }
+
+    @Override
+    public @Nullable JComponent getPreferredFocusedComponent() {
+        return delegate.getPreferredFocusedComponent();
+    }
+
+    @Override
+    public @NotNull String getName() {
+        return "FIX Dictionary";
+    }
+
+    @Override
+    public void setState(@NotNull FileEditorState state) {
+        delegate.setState(state);
+    }
+
+    @Override
+    public boolean isModified() {
+        return delegate.isModified();
+    }
+
+    @Override
+    public boolean isValid() {
+        return delegate.isValid();
+    }
+
+    @Override
+    public void selectNotify() {
+        delegate.selectNotify();
+    }
+
+    @Override
+    public void deselectNotify() {
+        delegate.deselectNotify();
+    }
+
+    @Override
+    public void addPropertyChangeListener(@NotNull java.beans.PropertyChangeListener listener) {
+        delegate.addPropertyChangeListener(listener);
+    }
+
+    @Override
+    public void removePropertyChangeListener(@NotNull java.beans.PropertyChangeListener listener) {
+        delegate.removePropertyChangeListener(listener);
+    }
+
+    @Override
+    public @Nullable FileEditorLocation getCurrentLocation() {
+        return delegate.getCurrentLocation();
+    }
+
+    @Override
+    public @NotNull FileEditorState getState(@NotNull FileEditorStateLevel level) {
+        return delegate.getState(level);
+    }
+
+    @Override
+    public void dispose() {
+        delegate.dispose();
+    }
+}

--- a/src/main/java/com/rannett/fixplugin/ui/FixDictionaryFileEditorProvider.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixDictionaryFileEditorProvider.java
@@ -3,7 +3,6 @@ package com.rannett.fixplugin.ui;
 import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.fileEditor.FileEditorPolicy;
 import com.intellij.openapi.fileEditor.FileEditorProvider;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -11,18 +10,13 @@ import com.rannett.fixplugin.dictionary.FixDictionaryXmlUtil;
 import org.jetbrains.annotations.NotNull;
 
 public class FixDictionaryFileEditorProvider implements FileEditorProvider, DumbAware {
-    private static final Logger LOG = Logger.getInstance(FixDictionaryFileEditorProvider.class);
-
     @Override
     public boolean accept(@NotNull Project project, @NotNull VirtualFile file) {
-        boolean accepted = FixDictionaryXmlUtil.isFixDictionaryFile(file);
-        LOG.warn("FIX dictionary editor accept(" + file.getPath() + ") = " + accepted);
-        return accepted;
+        return FixDictionaryXmlUtil.isFixDictionaryFile(file);
     }
 
     @Override
     public @NotNull FileEditor createEditor(@NotNull Project project, @NotNull VirtualFile file) {
-        LOG.warn("Creating FIX dictionary editor for: " + file.getPath());
         return new FixDictionaryFileEditor(project, file);
     }
 

--- a/src/main/java/com/rannett/fixplugin/ui/FixDictionaryFileEditorProvider.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixDictionaryFileEditorProvider.java
@@ -16,13 +16,13 @@ public class FixDictionaryFileEditorProvider implements FileEditorProvider, Dumb
     @Override
     public boolean accept(@NotNull Project project, @NotNull VirtualFile file) {
         boolean accepted = FixDictionaryXmlUtil.isFixDictionaryFile(file);
-        LOG.info("FIX dictionary editor accept(" + file.getPath() + ") = " + accepted);
+        LOG.warn("FIX dictionary editor accept(" + file.getPath() + ") = " + accepted);
         return accepted;
     }
 
     @Override
     public @NotNull FileEditor createEditor(@NotNull Project project, @NotNull VirtualFile file) {
-        LOG.info("Creating FIX dictionary editor for: " + file.getPath());
+        LOG.warn("Creating FIX dictionary editor for: " + file.getPath());
         return new FixDictionaryFileEditor(project, file);
     }
 

--- a/src/main/java/com/rannett/fixplugin/ui/FixDictionaryFileEditorProvider.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixDictionaryFileEditorProvider.java
@@ -1,0 +1,32 @@
+package com.rannett.fixplugin.ui;
+
+import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.fileEditor.FileEditorPolicy;
+import com.intellij.openapi.fileEditor.FileEditorProvider;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.rannett.fixplugin.dictionary.FixDictionaryXmlUtil;
+import org.jetbrains.annotations.NotNull;
+
+public class FixDictionaryFileEditorProvider implements FileEditorProvider, DumbAware {
+    @Override
+    public boolean accept(@NotNull Project project, @NotNull VirtualFile file) {
+        return FixDictionaryXmlUtil.isFixDictionaryFile(file);
+    }
+
+    @Override
+    public @NotNull FileEditor createEditor(@NotNull Project project, @NotNull VirtualFile file) {
+        return new FixDictionaryFileEditor(project, file);
+    }
+
+    @Override
+    public @NotNull String getEditorTypeId() {
+        return "fix-dictionary-view";
+    }
+
+    @Override
+    public @NotNull FileEditorPolicy getPolicy() {
+        return FileEditorPolicy.PLACE_AFTER_DEFAULT_EDITOR;
+    }
+}

--- a/src/main/java/com/rannett/fixplugin/ui/FixDictionaryFileEditorProvider.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixDictionaryFileEditorProvider.java
@@ -3,6 +3,7 @@ package com.rannett.fixplugin.ui;
 import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.fileEditor.FileEditorPolicy;
 import com.intellij.openapi.fileEditor.FileEditorProvider;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -10,13 +11,18 @@ import com.rannett.fixplugin.dictionary.FixDictionaryXmlUtil;
 import org.jetbrains.annotations.NotNull;
 
 public class FixDictionaryFileEditorProvider implements FileEditorProvider, DumbAware {
+    private static final Logger LOG = Logger.getInstance(FixDictionaryFileEditorProvider.class);
+
     @Override
     public boolean accept(@NotNull Project project, @NotNull VirtualFile file) {
-        return FixDictionaryXmlUtil.isFixDictionaryFile(file);
+        boolean accepted = FixDictionaryXmlUtil.isFixDictionaryFile(file);
+        LOG.info("FIX dictionary editor accept(" + file.getPath() + ") = " + accepted);
+        return accepted;
     }
 
     @Override
     public @NotNull FileEditor createEditor(@NotNull Project project, @NotNull VirtualFile file) {
+        LOG.info("Creating FIX dictionary editor for: " + file.getPath());
         return new FixDictionaryFileEditor(project, file);
     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -62,6 +62,9 @@
                                     implementationClass="com.rannett.fixplugin.quickfix.QuickFixConfigDocumentationProvider"/>
 
         <fileEditorProvider implementation="com.rannett.fixplugin.ui.FixDualViewEditorProvider"/>
+        <fileEditorProvider implementation="com.rannett.fixplugin.ui.FixDictionaryFileEditorProvider"/>
+        <psi.referenceContributor language="XML"
+                                  implementation="com.rannett.fixplugin.dictionary.FixDictionaryXmlReferenceContributor"/>
 
         <multiHostInjector
                 implementation="com.rannett.fixplugin.injection.FixStringLanguageInjector"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -92,5 +92,11 @@
                 description="Lookup FIX field information">
             <add-to-group group-id="ToolsMenu" anchor="last"/>
         </action>
+        <action id="GoToFixFieldDefinitionAction"
+                class="com.rannett.fixplugin.dictionary.GoToFixFieldDefinitionAction"
+                text="Go to FIX Field Definition"
+                description="Navigate to the FIX dictionary field definition">
+            <add-to-group group-id="EditorPopupMenu" anchor="first"/>
+        </action>
     </actions>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -65,6 +65,7 @@
         <fileEditorProvider implementation="com.rannett.fixplugin.ui.FixDictionaryFileEditorProvider"/>
         <psi.referenceContributor language="XML"
                                   implementation="com.rannett.fixplugin.dictionary.FixDictionaryXmlReferenceContributor"/>
+        <gotoDeclarationHandler implementation="com.rannett.fixplugin.dictionary.FixDictionaryGotoDeclarationHandler"/>
 
         <multiHostInjector
                 implementation="com.rannett.fixplugin.injection.FixStringLanguageInjector"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -94,8 +94,8 @@
         </action>
         <action id="GoToFixFieldDefinitionAction"
                 class="com.rannett.fixplugin.dictionary.GoToFixFieldDefinitionAction"
-                text="Go to FIX Field Definition"
-                description="Navigate to the FIX dictionary field definition">
+                text="Go to FIX Definition"
+                description="Navigate to the FIX dictionary field or component definition">
             <add-to-group group-id="EditorPopupMenu" anchor="first"/>
         </action>
     </actions>

--- a/src/test/java/com/rannett/fixplugin/dictionary/FixDictionaryXmlUtilTest.java
+++ b/src/test/java/com/rannett/fixplugin/dictionary/FixDictionaryXmlUtilTest.java
@@ -1,0 +1,21 @@
+package com.rannett.fixplugin.dictionary;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FixDictionaryXmlUtilTest {
+
+    @Test
+    public void detectsDictionaryShape() {
+        String xml = "<fix><fields></fields><messages></messages></fix>";
+        assertTrue(FixDictionaryXmlUtil.isFixDictionaryText(xml));
+    }
+
+    @Test
+    public void rejectsNonDictionaryXml() {
+        String xml = "<fix><fields></fields></fix>";
+        assertFalse(FixDictionaryXmlUtil.isFixDictionaryText(xml));
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a quickfix dictionary viewer by detecting QuickFIX dictionary XML files, exposing a dictionary-aware editor view while preserving the default XML editor.
- Enable dictionary-aware navigation so message-level `<field name="..."/>` references resolve to their canonical `<fields><field name="..."/>` definitions for quick jumps.
- Surface the feature in docs and changelog and add a small focused unit test for detection logic.

### Description

- Add `FixDictionaryXmlUtil` which detects QuickFIX dictionary XML by checking `xml` extension, presence of a `<fix>` root, and at least two of `messages|fields|components|header|trailer` (file: `src/main/java/com/rannett/fixplugin/dictionary/FixDictionaryXmlUtil.java`).
- Add a dedicated file editor and provider that places a `FIX Dictionary` tab after the default XML editor to keep the normal XML editor available (files: `FixDictionaryFileEditor.java`, `FixDictionaryFileEditorProvider.java`).
- Add an XML PSI reference contributor and reference implementation to resolve message-level `<field name="...">` attributes to the matching `<fields><field name="...">` definition (files: `FixDictionaryXmlReferenceContributor.java`, `FixDictionaryFieldReference.java`).
- Wire the editor provider and reference contributor into `plugin.xml`, update `README.md` and `CHANGELOG.md` to document the feature, and remove an unused import in `FixDictionaryXmlUtil`.
- Add `FixDictionaryXmlUtilTest` with positive and negative cases for the dictionary-shape detection (file: `src/test/java/com/rannett/fixplugin/dictionary/FixDictionaryXmlUtilTest.java`).

### Testing

- Ran the focused unit test `./gradlew test --tests com.rannett.fixplugin.dictionary.FixDictionaryXmlUtilTest` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a034a341200832c9383d85be8729864)