### PR TITLE
Bump pluginVersion to 0.0.22 and add 0.0.22 changelog/README notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 
 ### Added
 
+- None yet.
+
+### Fixed
+
+- None yet.
+
+## [0.0.22] - 2026-05-13
+
+### Added
+
 - Added split-message coverage for embedded XML data fields (212/213) and multi-message parsing with mixed valid/malformed input.
 - Detect QuickFIX dictionary XML files and open a dedicated `FIX Dictionary` file-editor tab alongside the default XML editor.
 - Add dictionary-aware navigation for message-level field references to their `<fields>` definitions.
@@ -28,10 +38,11 @@
 - Prioritize caret-near `<field>` tag resolution (excluding `<fields>` definitions) before attribute-value PSI paths to improve Ctrl+Click reliability across dictionary sections.
 - Fix right-click `Go to FIX Field Definition` visibility by deriving PSI from the active editor document when popup PSI context is unavailable.
 - Remove temporary verbose warning logs from dictionary navigation/editor paths after stabilizing fallback behavior.
-- Add dictionary navigation support for component references, resolving `<component name=\"...\"/>` to `<components><component .../>` definitions.
-- Fix dictionary XML reference-provider parent-tag checks so message-level `<field name=\"...\"/>` references produce navigation references correctly.
+- Add dictionary navigation support for component references, resolving `<component name="..."/>` to `<components><component .../>` definitions.
+- Fix dictionary XML reference-provider parent-tag checks so message-level `<field name="..."/>` references produce navigation references correctly.
 - Tighten dictionary detection to require `<fix>` as the XML document root, reducing false-positive activation in unrelated XML files.
 - Resolve static-analysis warnings for nullability override annotations, sentence capitalization in dictionary-view header text, and redundant constant-condition checks.
+- Bump `pluginVersion` to `0.0.22` in `gradle.properties` so IntelliJ release pickup matches the changelog release.
 
 ## [0.0.21] - 2026-05-06
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ There is also a tree view, to show the message structure, and a communications v
 - **FpML Detection** for XML embedded in tags 351 and 213
 - **QuickFIX/J 3.0.0 compatibility** with parser updates for the latest QuickFIX validation API and stable handling of encoded XML data tags 350/351.
 - **Embedded XML split robustness** for both `XmlDataLen/XmlData` (`212/213`) and `EncodedSecurityDescLen/EncodedSecurityDesc` (`350/351`) across multi-line, multi-message payloads.
+- **Mixed-quality log parsing** keeps extracting valid FIX messages even when malformed messages appear in the same input block.
 - **Malformed FIX resilience** in multi-message logs so invalid checksum lines do not block parsing of following valid messages.
 - **Lexer support** for multi-line FpML blocks
 - **Unlimited IDE compatibility** so the plugin can install on newer IntelliJ versions without a capped build range

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 pluginGroup=com.rannett.fix-viewer
 pluginName=Financial Information eXchange Message Viewer
 # SemVer format -> https://semver.org
-pluginVersion=0.0.21
+pluginVersion=0.0.22
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=242
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension


### PR DESCRIPTION
### Motivation
- Prepare and document the `0.0.22` release by adding the release notes to the changelog, updating README highlights, and ensuring the plugin metadata reflects the new version so IntelliJ picks up the release.

### Description
- Add a new `## [0.0.22] - 2026-05-13` section to `CHANGELOG.md` with fixes and improvements related to QuickFIX/J upgrade, dictionary navigation, and parsing robustness. 
- Normalize quoting/formatting for several changelog entries and reintroduce component reference navigation and XML reference-provider fixes. 
- Add a README note about mixed-quality log parsing in `README.md`.
- Bump `pluginVersion` to `0.0.22` in `gradle.properties` so the plugin metadata matches the changelog.

### Testing
- No automated tests were modified or run as part of this documentation and metadata update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a044fa1bac4832c95f761f8f9b65eb7)