### PR TITLE
Add Perspective CompID selector to Message Flow and make direction logic headless-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@
 
 ### Added
 
-- None yet.
+- Added a `Perspective CompID` selector to the Message Flow view so direction arrows are recalculated relative to the selected CompID (with Auto detection and unknown `?` routing state).
 
 ### Fixed
 
-- None yet.
+- Optimized Message Flow direction recalculation by caching the effective CompID per filter pass and fixed `Auto` selector collisions when a real CompID is literally `Auto`.
+- Fixed Message Flow CompID perspective filtering to avoid IntelliJ application-context NPEs in headless/unit-test execution while still updating UI normally in the IDE.
 
 ## [0.0.22] - 2026-05-13
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ There is also a tree view, to show the message structure, and a communications v
 - **Tooltips** showing tag descriptions (e.g., `35=8` → *Execution Report*)
 - **Transposed View** to make reading messages easier including filtering and field selection
 - **Tree View** to navigate message structure including groups
+- **Message Flow CompID perspective selector** to compute incoming/outgoing arrows relative to a chosen `SenderCompID(49)` / `TargetCompID(56)`, including an `Auto` option for mixed logs.
 - **Message Hiding** in the transposed view for large message files
 - **Enumerated Values** suggested as items in the table view
 - **Override Dictionaries** with bespoke ones. Standard Quickfix dictionaries are used.

--- a/src/main/java/com/rannett/fixplugin/ui/FixCommTimelinePanel.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixCommTimelinePanel.java
@@ -1,5 +1,6 @@
 package com.rannett.fixplugin.ui;
 
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.treeStructure.Tree;
 import com.intellij.ui.treeStructure.treetable.ListTreeTableModelOnColumns;
@@ -11,7 +12,11 @@ import com.rannett.fixplugin.util.FixMessageParser;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
 import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.DefaultListCellRenderer;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.table.TableColumn;
@@ -19,9 +24,9 @@ import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.TreePath;
 import java.awt.BorderLayout;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
@@ -36,14 +41,17 @@ import quickfix.Message;
  * summary column.
  */
 public class FixCommTimelinePanel extends JPanel {
+    private static final CompIdOption AUTO_COMP_ID_OPTION = new CompIdOption("", true);
+
     private final JCheckBox hideHeartbeat;
+    private final JComboBox<CompIdOption> compIdSelector;
     private final List<MessageNode> allNodes = new ArrayList<>();
     private final List<MessageNode> displayedNodes = new ArrayList<>();
-    private final Map<String, String> localPartyBySession = new HashMap<>();
     private final DefaultMutableTreeNode root = new DefaultMutableTreeNode("root");
     private final ListTreeTableModelOnColumns model;
     private final TreeTable table;
     private Consumer<Integer> onMessageSelected;
+    private boolean suppressCompIdChangeEvent;
 
     /**
      * Create a timeline panel for the provided messages.
@@ -91,15 +99,46 @@ public class FixCommTimelinePanel extends JPanel {
         hideHeartbeat = new JCheckBox("Hide heartbeats");
         hideHeartbeat.addActionListener(e -> applyFilter());
 
+        compIdSelector = new JComboBox<>();
+        compIdSelector.setRenderer(new DefaultListCellRenderer() {
+            @Override
+            public java.awt.Component getListCellRendererComponent(javax.swing.JList<?> list,
+                                                                   Object value,
+                                                                   int index,
+                                                                   boolean isSelected,
+                                                                   boolean cellHasFocus) {
+                Object displayValue = value;
+                if (value instanceof CompIdOption) {
+                    displayValue = ((CompIdOption) value).toDisplayLabel();
+                }
+                return super.getListCellRendererComponent(list, displayValue, index, isSelected, cellHasFocus);
+            }
+        });
+        compIdSelector.setToolTipText("Direction is shown relative to selected CompID.");
+
+        JPanel controls = new JPanel();
+        controls.setLayout(new BoxLayout(controls, BoxLayout.X_AXIS));
+        JLabel compIdLabel = new JLabel("Perspective CompID:");
+        compIdLabel.setToolTipText("Direction is shown relative to selected CompID.");
+        controls.add(compIdLabel);
+        controls.add(compIdSelector);
+        controls.add(new JLabel("   "));
+        controls.add(hideHeartbeat);
+
         JScrollPane scroll = new JBScrollPane(table);
         scroll.setBorder(BorderFactory.createEmptyBorder());
-        add(hideHeartbeat, BorderLayout.NORTH);
+        add(controls, BorderLayout.NORTH);
         add(scroll, BorderLayout.CENTER);
 
         Tree tree = table.getTree();
         tree.addTreeSelectionListener(e -> notifySelection());
 
         loadMessages(messages);
+        compIdSelector.addActionListener(e -> {
+            if (!suppressCompIdChangeEvent && ApplicationManager.getApplication() != null) {
+                applyFilter();
+            }
+        });
 
         fixColumnWidths();
     }
@@ -143,24 +182,33 @@ public class FixCommTimelinePanel extends JPanel {
 
     private void loadMessages(List<String> messages) {
         allNodes.clear();
-        localPartyBySession.clear();
         IntStream.range(0, messages.size()).forEach(i -> {
             MessageNode node = parseNode(messages.get(i), i + 1);
             allNodes.add(node);
         });
+        refreshCompIdSelector();
         applyFilter();
     }
 
     private void applyFilter() {
-        root.removeAllChildren();
+        boolean ideApplicationReady = ApplicationManager.getApplication() != null;
+        String effectiveCompId = getEffectiveCompIdForDirection();
+        if (ideApplicationReady) {
+            root.removeAllChildren();
+        }
         displayedNodes.clear();
         allNodes.stream()
                 .filter(n -> !hideHeartbeat.isSelected() || !"0".equals(n.msgTypeCode))
                 .forEach(n -> {
+                    n.direction = determineDirection(n.senderCompId, n.targetCompId, effectiveCompId);
                     displayedNodes.add(n);
-                    root.add(n);
+                    if (ideApplicationReady) {
+                        root.add(n);
+                    }
                 });
-        model.setRoot(root);
+        if (ideApplicationReady) {
+            model.reload();
+        }
     }
 
     private void notifySelection() {
@@ -185,10 +233,10 @@ public class FixCommTimelinePanel extends JPanel {
             String typeName = buildTypeName(dd, typeCode);
             String sender = parsed.getHeader().isSetField(49) ? parsed.getHeader().getString(49) : "";
             String target = parsed.getHeader().isSetField(56) ? parsed.getHeader().getString(56) : "";
-            String direction = determineDirection(sender, target);
+            String direction = determineDirection(sender, target, guessAutoCompId());
             String summary = FixMessageParser.buildMessageLabel(parsed, dd);
 
-            MessageNode node = new MessageNode(index, time, direction, typeCode, typeName, summary);
+            MessageNode node = new MessageNode(index, time, direction, typeCode, typeName, summary, sender, target);
             DefaultMutableTreeNode headerNode = new DefaultMutableTreeNode("Header");
             buildNodes(parsed.getHeader(), headerNode, dd);
             node.add(headerNode);
@@ -202,7 +250,7 @@ public class FixCommTimelinePanel extends JPanel {
             node.add(trailerNode);
             return node;
         } catch (Exception e) {
-            MessageNode node = new MessageNode(index, "", "→", "", "", msg);
+            MessageNode node = new MessageNode(index, "", "?", "", "", msg, "", "");
             node.add(new DefaultMutableTreeNode("Parse error: " + e.getMessage()));
             return node;
         }
@@ -232,27 +280,71 @@ public class FixCommTimelinePanel extends JPanel {
         return "FIX.4.4";
     }
 
-    private String determineDirection(String sender, String target) {
+    private String determineDirection(String sender, String target, String selectedCompId) {
         if (sender.isEmpty() || target.isEmpty()) {
+            return "?";
+        }
+        if (selectedCompId.isEmpty()) {
+            return "?";
+        }
+        if (selectedCompId.equals(sender)) {
             return "→";
         }
-        String key = sessionKey(sender, target);
-        String local = localPartyBySession.get(key);
-        if (local == null) {
-            localPartyBySession.put(key, sender);
-            local = sender;
+        if (selectedCompId.equals(target)) {
+            return "←";
         }
-        if (sender.equals(local)) {
-            return "→";
-        }
-        return "←";
+        return "?";
     }
 
-    private static String sessionKey(String a, String b) {
-        if (a.compareTo(b) < 0) {
-            return a + "|" + b;
+    private void refreshCompIdSelector() {
+        Set<String> compIds = new HashSet<>();
+        allNodes.forEach(node -> {
+            if (!node.senderCompId.isEmpty()) {
+                compIds.add(node.senderCompId);
+            }
+            if (!node.targetCompId.isEmpty()) {
+                compIds.add(node.targetCompId);
+            }
+        });
+
+        CompIdOption previous = (CompIdOption) compIdSelector.getSelectedItem();
+        suppressCompIdChangeEvent = true;
+        compIdSelector.removeAllItems();
+        compIdSelector.addItem(AUTO_COMP_ID_OPTION);
+        compIds.stream().sorted().map(compId -> new CompIdOption(compId, false)).forEach(compIdSelector::addItem);
+        if (previous != null && !previous.isAuto && compIds.contains(previous.value)) {
+            compIdSelector.setSelectedItem(previous);
+        } else {
+            compIdSelector.setSelectedItem(AUTO_COMP_ID_OPTION);
         }
-        return b + "|" + a;
+        suppressCompIdChangeEvent = false;
+    }
+
+    private String getEffectiveCompIdForDirection() {
+        CompIdOption selectedCompIdOption = (CompIdOption) compIdSelector.getSelectedItem();
+        if (selectedCompIdOption == null || selectedCompIdOption.isAuto) {
+            return guessAutoCompId();
+        }
+        return selectedCompIdOption.value;
+    }
+
+    private String guessAutoCompId() {
+        return allNodes.stream()
+                .flatMap(node -> java.util.stream.Stream.of(node.senderCompId, node.targetCompId))
+                .filter(compId -> !compId.isEmpty())
+                .collect(java.util.stream.Collectors.groupingBy(compId -> compId, java.util.stream.Collectors.counting()))
+                .entrySet()
+                .stream()
+                .sorted((a, b) -> {
+                    int countCompare = Long.compare(b.getValue(), a.getValue());
+                    if (countCompare != 0) {
+                        return countCompare;
+                    }
+                    return a.getKey().compareTo(b.getKey());
+                })
+                .map(java.util.Map.Entry::getKey)
+                .findFirst()
+                .orElse("");
     }
 
     /**
@@ -339,22 +431,58 @@ public class FixCommTimelinePanel extends JPanel {
         return table.getColumnModel().getColumn(index).getPreferredWidth();
     }
 
+    void setSelectedCompId(String compId) {
+        suppressCompIdChangeEvent = true;
+        for (int i = 0; i < compIdSelector.getItemCount(); i++) {
+            CompIdOption item = compIdSelector.getItemAt(i);
+            if (!item.isAuto && item.value.equals(compId)) {
+                compIdSelector.setSelectedIndex(i);
+                suppressCompIdChangeEvent = false;
+                applyFilter();
+                return;
+            }
+        }
+        compIdSelector.setSelectedItem(AUTO_COMP_ID_OPTION);
+        suppressCompIdChangeEvent = false;
+        applyFilter();
+    }
+
+    private static final class CompIdOption {
+        final String value;
+        final boolean isAuto;
+
+        CompIdOption(String value, boolean isAuto) {
+            this.value = value;
+            this.isAuto = isAuto;
+        }
+
+        String toDisplayLabel() {
+            if (isAuto) {
+                return "Auto";
+            }
+            return value;
+        }
+    }
+
     private static final class MessageNode extends DefaultMutableTreeNode {
         final int index;
         final String time;
-        final String direction;
+        String direction;
         final String msgTypeCode;
         final String msgTypeDisplay;
+        final String senderCompId;
+        final String targetCompId;
 
-        MessageNode(int index, String time, String direction, String msgTypeCode, String msgTypeDisplay, String summary) {
+        MessageNode(int index, String time, String direction, String msgTypeCode, String msgTypeDisplay, String summary, String senderCompId, String targetCompId) {
             super(summary);
             this.index = index;
             this.time = time;
             this.direction = direction;
             this.msgTypeCode = msgTypeCode;
             this.msgTypeDisplay = msgTypeDisplay;
+            this.senderCompId = senderCompId;
+            this.targetCompId = targetCompId;
         }
     }
 
 }
-

--- a/src/test/java/com/rannett/fixplugin/ui/FixCommTimelinePanelTest.java
+++ b/src/test/java/com/rannett/fixplugin/ui/FixCommTimelinePanelTest.java
@@ -23,7 +23,7 @@ public class FixCommTimelinePanelTest {
     }
 
     @Test
-    public void testDirectionDetection() throws Exception {
+    public void testDirectionDetectionWithAutoPerspective() throws Exception {
         List<String> messages = List.of(
                 "8=FIXT.1.1|9=65|35=A|34=1|49=BUY_SIDE|56=SELL_SIDE|52=20250829-09:00:00.000|98=0|108=30|141=Y|10=072|",
                 "8=FIXT.1.1|9=65|35=A|34=1|49=SELL_SIDE|56=BUY_SIDE|52=20250829-09:00:00.100|98=0|108=30|141=Y|10=082|",
@@ -36,6 +36,26 @@ public class FixCommTimelinePanelTest {
             assertEquals("←", panel.getDirectionAtRow(1));
             assertEquals("→", panel.getDirectionAtRow(2));
             assertEquals("←", panel.getDirectionAtRow(3));
+        });
+    }
+
+    @Test
+    public void testDirectionDetectionWithSelectedCompId() throws Exception {
+        List<String> messages = List.of(
+                "8=FIX.4.4|35=D|49=CLIENT|56=BROKER|10=001|",
+                "8=FIX.4.4|35=8|49=BROKER|56=CLIENT|10=002|",
+                "8=FIX.4.4|35=0|49=A|56=B|10=003|"
+        );
+        SwingUtilities.invokeAndWait(() -> {
+            FixCommTimelinePanel panel = new FixCommTimelinePanel(messages);
+            panel.setSelectedCompId("CLIENT");
+            assertEquals("→", panel.getDirectionAtRow(0));
+            assertEquals("←", panel.getDirectionAtRow(1));
+            assertEquals("?", panel.getDirectionAtRow(2));
+
+            panel.setSelectedCompId("BROKER");
+            assertEquals("←", panel.getDirectionAtRow(0));
+            assertEquals("→", panel.getDirectionAtRow(1));
         });
     }
 


### PR DESCRIPTION
### Motivation

- Provide a user-selectable `CompID` perspective so message direction arrows are computed relative to a chosen `SenderCompID(49)`/`TargetCompID(56)` instead of guessing globally.
- Avoid IntelliJ application-context NPEs when running in headless/unit-test environments by not touching UI tree/model when the IDEA `Application` is not available.

### Description

- Add a `Perspective CompID` `JComboBox` to `FixCommTimelinePanel` with an `Auto` option and a compact `CompIdOption` wrapper to avoid collisions with literal values.
- Change `MessageNode` to retain `senderCompId`/`targetCompId` and compute cached `effectiveCompId` per filter pass via `getEffectiveCompIdForDirection()` and `guessAutoCompId()` to optimize recalculation.
- Update direction logic in `determineDirection` to use the selected or auto-detected CompID and return `?` when direction cannot be determined, and add `setSelectedCompId` + `refreshCompIdSelector` helpers.
- Make UI updates tolerant of headless testing by gating tree/model mutations with an `ideApplicationReady` check using `ApplicationManager.getApplication()` and suppressing selector change events during programmatic updates.
- Update `README.md` and `CHANGELOG.md` to document the new selector and the related fixes/enhancements.

### Testing

- Ran `FixCommTimelinePanelTest` which includes `testHideHeartbeats`, `testDirectionDetectionWithAutoPerspective`, `testDirectionDetectionWithSelectedCompId`, `testMsgTypeNames`, and `testColumnOrderAndWidth` as Swing-invoked unit tests.
- All unit tests executed locally under the CI/headless test harness passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07102caddc832c9d5f2dad78701c9f)