### PR TITLE
[codex] Coalesce dictionary tree refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Coalesced FIX dictionary Message Tree refreshes while editing source XML to avoid repeated full reparses during typing.
 
 ## [0.0.24] - 2026-06-01
 

--- a/src/main/java/com/rannett/fixplugin/ui/FixDictionaryFileEditor.java
+++ b/src/main/java/com/rannett/fixplugin/ui/FixDictionaryFileEditor.java
@@ -20,12 +20,14 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.JPanel;
 import javax.swing.JComponent;
+import javax.swing.event.ChangeListener;
 import java.awt.BorderLayout;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class FixDictionaryFileEditor extends UserDataHolderBase implements FileEditor {
     private static final int SOURCE_TAB_INDEX = 0;
+    private static final int MESSAGE_TREE_TAB_INDEX = 1;
 
     private final TextEditor delegate;
     private final VirtualFile file;
@@ -33,28 +35,29 @@ public class FixDictionaryFileEditor extends UserDataHolderBase implements FileE
     private final FixDictionaryTreePanel treePanel;
     private final Document document;
     private final DocumentListener documentListener;
+    private final ChangeListener tabSelectionListener;
     private final JBTabbedPane tabbedPane;
+    private boolean dictionaryTreeDirty;
+    private int dictionaryTreeRefreshGeneration;
 
     public FixDictionaryFileEditor(@NotNull Project project, @NotNull VirtualFile file) {
         this.file = file;
         this.delegate = (TextEditor) TextEditorProvider.getInstance().createEditor(project, file);
         this.document = delegate.getEditor().getDocument();
         this.treePanel = new FixDictionaryTreePanel(document.getText(), this::navigateToFieldDefinition);
-        this.documentListener = new DocumentListener() {
-            @Override
-            public void documentChanged(@NotNull DocumentEvent event) {
-                ApplicationManager.getApplication().invokeLater(() -> {
-                    if (!project.isDisposed()) {
-                        treePanel.updateDictionaryText(document.getText());
-                    }
-                });
-            }
-        };
-        document.addDocumentListener(documentListener);
-
         tabbedPane = new JBTabbedPane();
         tabbedPane.addTab("Source", delegate.getComponent());
         tabbedPane.addTab("Message Tree", treePanel);
+        this.tabSelectionListener = event -> scheduleDictionaryTreeRefresh(project);
+        tabbedPane.addChangeListener(tabSelectionListener);
+        this.documentListener = new DocumentListener() {
+            @Override
+            public void documentChanged(@NotNull DocumentEvent event) {
+                dictionaryTreeDirty = true;
+                scheduleDictionaryTreeRefresh(project);
+            }
+        };
+        document.addDocumentListener(documentListener);
 
         this.panel = new JPanel(new BorderLayout());
         this.panel.add(tabbedPane, BorderLayout.CENTER);
@@ -73,6 +76,24 @@ public class FixDictionaryFileEditor extends UserDataHolderBase implements FileE
     @Override
     public @NotNull String getName() {
         return "FIX Dictionary";
+    }
+
+    private void scheduleDictionaryTreeRefresh(@NotNull Project project) {
+        if (tabbedPane.getSelectedIndex() != MESSAGE_TREE_TAB_INDEX) {
+            return;
+        }
+
+        int refreshGeneration = ++dictionaryTreeRefreshGeneration;
+        ApplicationManager.getApplication().invokeLater(() -> {
+            if (project.isDisposed()
+                    || refreshGeneration != dictionaryTreeRefreshGeneration
+                    || !dictionaryTreeDirty
+                    || tabbedPane.getSelectedIndex() != MESSAGE_TREE_TAB_INDEX) {
+                return;
+            }
+            dictionaryTreeDirty = false;
+            treePanel.updateDictionaryText(document.getText());
+        });
     }
 
     private void navigateToFieldDefinition(String fieldName) {
@@ -163,6 +184,7 @@ public class FixDictionaryFileEditor extends UserDataHolderBase implements FileE
     @Override
     public void dispose() {
         document.removeDocumentListener(documentListener);
+        tabbedPane.removeChangeListener(tabSelectionListener);
         delegate.dispose();
     }
 }


### PR DESCRIPTION
## Summary

- Coalesce FIX dictionary Message Tree refreshes so stale queued UI updates are skipped.
- Avoid rebuilding the Message Tree while the Source tab is active; refresh once when the Message Tree tab is selected.
- Add an Unreleased changelog entry for the fix.

## Root Cause

Every dictionary source document edit queued an EDT task that reparsed the full XML document and rebuilt the Message Tree model, even when the tree tab was not visible. Rapid typing could queue several full reparses against the latest text and make the IDE lag on larger dictionaries.

## Validation

- `./gradlew.bat compileJava` passed.
- `./gradlew.bat test --tests com.rannett.fixplugin.ui.FixDictionaryTreePanelTest --tests com.rannett.fixplugin.ui.FixDictionaryFileEditorProviderTest` reached `compileTestJava`, then failed at `:instrumentCode` because `C:\Program Files\Microsoft\jdk-21.0.9.10-hotspot\Packages` does not exist in this environment.
- `git diff --check` passed.

Closes #138